### PR TITLE
Adding more cookie and custom user agent to be able to call NSE /api URLs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,8 @@ export class NseIndia {
     private baseHeaders = {
         'Accept-Language': 'en-US,en;q=0.9',
         'Accept-Encoding': 'gzip, deflate, br',
-        'Connection': 'keep-alive'
+        'Connection': 'keep-alive',
+        'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/118.0'
     }
 
     private async getNseCookies() {
@@ -51,7 +52,7 @@ export class NseIndia {
             const setCookies = response.headers['set-cookie']
             const cookies: string[] = []
             setCookies.forEach((cookie: string) => {
-                const requiredCookies: string[] = ['nsit', 'nseappid', 'ak_bmsc', 'AKA_A2']
+                const requiredCookies: string[] = ['nsit', 'nseappid', 'ak_bmsc', 'AKA_A2', 'bm_mi', 'bm_sv', 'RT']
                 const cookieKeyValue = cookie.split(';')[0]
                 const cookieEntry = cookieKeyValue.split('=')
                 if (requiredCookies.includes(cookieEntry[0])) {


### PR DESCRIPTION
I recently observed that I can't call https://www.nseindia.com/api/* URLs anymore. Application would just hang when I called the /api urls. On further investigation I found, NSE started to put couple more cookies which are require to be send in /api requests otherwise NSE would respond "Unauthorized". So in this pull request I have added those new cookies. I also observed that NSE has probably started checking User-Agent in requests as well, though I am not very sure about it.