### PR TITLE
feat: add historical chart data (OHLC) support with symbol lookup and MCP integration

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -266,7 +266,7 @@ describe('Class: NseIndia', () => {
         expect(indicators).toHaveProperty('momentum')
         expect(indicators).toHaveProperty('ad')
         expect(indicators).toHaveProperty('vwap')
-        
+
         // Verify structure of key indicators
         expect(Array.isArray(indicators.rsi)).toBe(true)
         expect(indicators.rsi.length).toBeGreaterThan(0)
@@ -300,6 +300,54 @@ describe('Class: NseIndia', () => {
         expect(indicators.ema).toHaveProperty('ema5')
         expect(indicators.ema).toHaveProperty('ema10')
     })
+
+    test('getEquityChartHistoricalData', async () => {
+        // Test charting API with real parameters
+        const chartData = await nseIndia.getEquityChartHistoricalData(
+            'ONGC-EQ',
+            '1775834999',
+            '1775999513',
+            '2475',
+            'Equity',
+            'I',
+            '5'
+        )
+        // Verify response structure
+        expect(chartData).toBeDefined()
+        expect(chartData).toHaveProperty('status')
+        expect(chartData).toHaveProperty('data')
+        expect(Array.isArray(chartData.data)).toBe(true)
+        if (chartData.data.length > 0) {
+            // Verify each candle has necessary fields
+            const candle = chartData.data[0]
+            expect(candle).toBeDefined()
+        }
+    })
+
+    test('getEquitySymbolInfo', async () => {
+        const info = await nseIndia.getEquitySymbolInfo('ONGC-EQ')
+        expect(info).toBeDefined()
+        expect(info).toHaveProperty('symbol')
+        expect(info).toHaveProperty('scripCode')
+        // scripCode is the token required by the chart API — must be a non-empty string
+        expect(typeof info.scripCode).toBe('string')
+        expect(info.scripCode.length).toBeGreaterThan(0)
+    })
+
+    test('getEquityChartHistoricalData without token (auto-lookup)', async () => {
+        // Token omitted — the method should call getEquitySymbolInfo internally
+        const chartData = await nseIndia.getEquityChartHistoricalData(
+            'ONGC-EQ',
+            '1775834999',
+            '1775999513'
+            // no token — should auto-fetch via symbolsDynamic
+        )
+        expect(chartData).toBeDefined()
+        expect(chartData).toHaveProperty('status')
+        expect(chartData).toHaveProperty('data')
+        expect(Array.isArray(chartData.data)).toBe(true)
+    })
+
 
     describe('ApiList', () => {
         Object.entries(ApiList).forEach(entry => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,11 @@ export class NseIndia {
      * @returns Charting domain cookies
      */
     private async getChartingCookies() {
-        if (this.chartingCookies === '' || this.chartingCookieUsedCount > 10 || this.chartingCookieExpiry <= new Date().getTime()) {
+        if (
+            this.chartingCookies === '' ||
+            this.chartingCookieUsedCount > 10 ||
+            this.chartingCookieExpiry <= new Date().getTime()
+        ) {
             const userAgent = new UserAgent().toString()
             const response = await axios.get(`${this.chartingBaseUrl}/`, {
                 headers: {
@@ -254,8 +258,8 @@ export class NseIndia {
         fromDate: string | number,
         toDate: string | number,
         token?: string | number,
-        symbolType: string = 'Equity',
-        chartType: string = 'I',
+        symbolType = 'Equity',
+        chartType = 'I',
         timeInterval: string | number = '5'
     ): Promise<ChartingOHLCResponse> {
         // Auto-fetch token (scripCode) when not supplied by the caller
@@ -287,24 +291,29 @@ export class NseIndia {
      */
     async getEquitySymbolInfo(
         symbol: string,
-        segment: string = ''
+        segment = ''
     ): Promise<ChartingSymbolInfo> {
         const url = `${this.chartingBaseUrl}/v1/exchanges/symbolsDynamic` +
             `?symbol=${encodeURIComponent(symbol)}&segment=${encodeURIComponent(segment)}`
 
         const response = await this.getData(url, 'charting')
 
+        let symbolList = response
+        if (!Array.isArray(response) && response && typeof response === 'object' && Array.isArray(response.data)) {
+            symbolList = response.data
+        }
+
         // The API returns an array; pick the best match: prefer exact symbol match
-        if (!Array.isArray(response) || response.length === 0) {
+        if (!Array.isArray(symbolList) || symbolList.length === 0) {
             throw new Error(`No symbol info found for: ${symbol}`)
         }
 
         // Try exact match first (symbol === input), fall back to first result
         const upperSymbol = symbol.toUpperCase()
-        const exact = response.find((s: any) =>
+        const exact = symbolList.find((s: any) =>
             s.symbol?.toUpperCase() === upperSymbol
         )
-        return exact ?? response[0]
+        return exact ?? symbolList[0]
     }
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,9 @@ import {
     PreOpenMarketData,
     MergedDailyReportsData,
     TechnicalIndicators,
+    ChartingSymbolInfo,
+    ChartingOHLCItem,
+    ChartingOHLCResponse,
     // Nested interfaces
     EquityInfo,
     EquityMetadata,
@@ -83,13 +86,17 @@ export class NseIndia {
     private cookieUsedCount = 0
     private cookieExpiry = new Date().getTime() + (this.cookieMaxAge * 1000)
     private noOfConnections = 0
-    
+    private readonly chartingBaseUrl = 'https://charting.nseindia.com'
+    private chartingCookies = ''
+    private chartingCookieUsedCount = 0
+    private chartingCookieExpiry = new Date().getTime() + (this.cookieMaxAge * 1000)
+
 
     private async getNseCookies() {
         if (this.cookies === '' || this.cookieUsedCount > 10 || this.cookieExpiry <= new Date().getTime()) {
             this.userAgent = new UserAgent().toString()
             const response = await axios.get(`${this.baseUrl}/get-quotes/equity?symbol=TCS`, {
-                headers: {...this.baseHeaders,'User-Agent': this.userAgent}
+                headers: { ...this.baseHeaders, 'User-Agent': this.userAgent }
             })
             const setCookies: string[] | undefined = response.headers['set-cookie']
             const cookies: string[] = []
@@ -108,31 +115,112 @@ export class NseIndia {
         this.cookieUsedCount++
         return this.cookies
     }
+
+    /**
+     * Get cookies for charting.nseindia.com domain
+     * Used as fallback when charting API fails with NSE cookies
+     * @returns Charting domain cookies
+     */
+    private async getChartingCookies() {
+        if (this.chartingCookies === '' || this.chartingCookieUsedCount > 10 || this.chartingCookieExpiry <= new Date().getTime()) {
+            const userAgent = new UserAgent().toString()
+            const response = await axios.get(`${this.chartingBaseUrl}/`, {
+                headers: {
+                    'Authority': 'charting.nseindia.com',
+                    'Referer': `${this.chartingBaseUrl}/`,
+                    'Accept': '*/*',
+                    'Accept-Language': 'en-US,en;q=0.9',
+                    'Accept-Encoding': 'application/json, text/plain, */*',
+                    'Connection': 'keep-alive',
+                    'User-Agent': userAgent
+                }
+            })
+            const setCookies: string[] | undefined = response.headers['set-cookie']
+            const cookies: string[] = []
+            if (setCookies) {
+                setCookies.forEach((cookie: string) => {
+                    const cookieKeyValue = cookie.split(';')[0]
+                    cookies.push(cookieKeyValue)
+                })
+                this.chartingCookies = cookies.join('; ')
+                this.chartingCookieUsedCount = 0
+                this.chartingCookieExpiry = new Date().getTime() + (this.cookieMaxAge * 1000)
+            }
+            this.chartingCookieUsedCount++
+            return this.chartingCookies
+        }
+        this.chartingCookieUsedCount++
+        return this.chartingCookies
+    }
     /**
      * 
-     * @param url NSE API's URL
-     * @returns JSON data from NSE India
+     * @param url NSE API's URL or charting API URL
+     * @param domain Domain type: 'nse' for www.nseindia.com, 'charting' for charting.nseindia.com
+     * @returns JSON data from NSE India or charting service
      */
-    async getData(url: string): Promise<any> {
+    async getData(url: string, domain: 'nse' | 'charting' = 'nse'): Promise<any> {
         let retries = 0
         let hasError = false
+        let lastError: any = null
+
         do {
             while (this.noOfConnections >= 5) {
                 await sleep(500)
             }
             this.noOfConnections++
             try {
-                const response = await axios.get(url, {
-                    headers: {
-                        ...this.baseHeaders,
-                        'Cookie': await this.getNseCookies(),
-                        'User-Agent': this.userAgent
+                if (domain === 'charting') {
+                    // For charting domain: try NSE cookies first, then fallback to charting cookies
+                    const chartingHeaders = {
+                        'Authority': 'charting.nseindia.com',
+                        'Referer': `${this.chartingBaseUrl}/`,
+                        'Accept': 'application/json, text/plain, */*',
+                        'Accept-Language': 'en-GB,en;q=0.5',
+                        'Accept-Encoding': 'application/json, text/plain, */*',
+                        'Connection': 'keep-alive'
                     }
-                })
-                this.noOfConnections--
-                return response.data
+
+                    let cookies = await this.getNseCookies() // Try NSE cookies first (PRIMARY)
+                    let response: any
+
+                    try {
+                        response = await axios.get(url, {
+                            headers: {
+                                ...chartingHeaders,
+                                'Cookie': cookies,
+                                'User-Agent': this.userAgent
+                            }
+                        })
+                    } catch (primaryError) {
+                        // NSE cookies failed, try charting cookies (FALLBACK)
+                        lastError = primaryError
+                        cookies = await this.getChartingCookies()
+                        response = await axios.get(url, {
+                            headers: {
+                                ...chartingHeaders,
+                                'Cookie': cookies,
+                                'User-Agent': this.userAgent
+                            }
+                        })
+                    }
+
+                    this.noOfConnections--
+                    return response.data
+                } else {
+                    // For NSE domain: use standard NSE headers
+                    const response = await axios.get(url, {
+                        headers: {
+                            ...this.baseHeaders,
+                            'Cookie': await this.getNseCookies(),
+                            'User-Agent': this.userAgent
+                        }
+                    })
+                    this.noOfConnections--
+                    return response.data
+                }
             } catch (error) {
                 hasError = true
+                lastError = error
                 retries++
                 this.noOfConnections--
                 if (retries >= 10)
@@ -148,6 +236,77 @@ export class NseIndia {
     async getDataByEndpoint(apiEndpoint: string): Promise<any> {
         return this.getData(`${this.baseUrl}${apiEndpoint}`)
     }
+
+    /**
+     * Get historical chart data from charting.nseindia.com
+     * @param symbol Equity symbol with series (e.g., 'ONGC-EQ')
+     * @param fromDate Unix timestamp for start date
+     * @param toDate Unix timestamp for end date
+     * @param token NSE script code (token) for the symbol. If not provided, it is
+     *              automatically fetched via {@link getEquitySymbolInfo}.
+     * @param symbolType Type of symbol (e.g., 'Equity', 'Index')
+     * @param chartType Chart type (e.g., 'I' for intraday, 'D' for daily)
+     * @param timeInterval Time interval in minutes (e.g., '5', '15', '60')
+     * @returns Chart data from charting service
+     */
+    async getEquityChartHistoricalData(
+        symbol: string,
+        fromDate: string | number,
+        toDate: string | number,
+        token?: string | number,
+        symbolType: string = 'Equity',
+        chartType: string = 'I',
+        timeInterval: string | number = '5'
+    ): Promise<ChartingOHLCResponse> {
+        // Auto-fetch token (scripCode) when not supplied by the caller
+        let resolvedToken = token
+        if (!resolvedToken) {
+            const symbolInfo = await this.getEquitySymbolInfo(symbol)
+            resolvedToken = symbolInfo.scripCode
+        }
+
+        const url = `${this.chartingBaseUrl}/v1/charts/symbolHistoricalData?` +
+            `fromDate=${fromDate}&` +
+            `toDate=${toDate}&` +
+            `symbol=${encodeURIComponent(symbol)}&` +
+            `token=${resolvedToken}&` +
+            `symbolType=${encodeURIComponent(symbolType)}&` +
+            `chartType=${encodeURIComponent(chartType)}&` +
+            `timeInterval=${timeInterval}`
+
+        return this.getData(url, 'charting')
+    }
+
+    /**
+     * Look up the NSE script code (token) for an equity symbol using the charting domain.
+     * The `scripCode` in the returned object is the value that must be passed as `token`
+     * to {@link getEquityChartHistoricalData}.
+     * @param symbol Equity symbol with series code (e.g., 'ONGC-EQ') OR plain symbol (e.g., 'ONGC')
+     * @param segment Optional market segment filter (default: empty string, returns all segments)
+     * @returns Symbol information including scripCode / token
+     */
+    async getEquitySymbolInfo(
+        symbol: string,
+        segment: string = ''
+    ): Promise<ChartingSymbolInfo> {
+        const url = `${this.chartingBaseUrl}/v1/exchanges/symbolsDynamic` +
+            `?symbol=${encodeURIComponent(symbol)}&segment=${encodeURIComponent(segment)}`
+
+        const response = await this.getData(url, 'charting')
+
+        // The API returns an array; pick the best match: prefer exact symbol match
+        if (!Array.isArray(response) || response.length === 0) {
+            throw new Error(`No symbol info found for: ${symbol}`)
+        }
+
+        // Try exact match first (symbol === input), fall back to first result
+        const upperSymbol = symbol.toUpperCase()
+        const exact = response.find((s: any) =>
+            s.symbol?.toUpperCase() === upperSymbol
+        )
+        return exact ?? response[0]
+    }
+
     /**
      * 
      * @returns List of NSE equity symbols
@@ -296,13 +455,13 @@ export class NseIndia {
                 const today = new Date()
                 /* istanbul ignore next */
                 today.setHours(0, 0, 0, 0) // Reset time to start of day for comparison
-                
+
                 // Find the nearest upcoming expiry date
                 /* istanbul ignore next */
                 let nearestExpiry: string | null = null
                 /* istanbul ignore next */
                 let nearestDate: Date | null = null
-                
+
                 /* istanbul ignore next */
                 for (const expiryDateStr of contractInfo.expiryDates) {
                     // Parse date in DD-MMM-YYYY format
@@ -321,14 +480,14 @@ export class NseIndia {
                         const month = monthNames.indexOf(dateParts[1])
                         /* istanbul ignore next */
                         const year = parseInt(dateParts[2], 10)
-                        
+
                         /* istanbul ignore next */
                         if (month !== -1) {
                             /* istanbul ignore next */
                             const expiryDate = new Date(year, month, day)
                             /* istanbul ignore next */
                             expiryDate.setHours(0, 0, 0, 0)
-                            
+
                             // Check if this expiry is in the future or today
                             /* istanbul ignore next */
                             if (expiryDate >= today) {
@@ -343,7 +502,7 @@ export class NseIndia {
                         }
                     }
                 }
-                
+
                 /* istanbul ignore next */
                 if (nearestExpiry) {
                     /* istanbul ignore next */
@@ -375,7 +534,7 @@ export class NseIndia {
             /* istanbul ignore next */
             throw new Error('Failed to determine expiry date')
         }
-        
+
         return this.getDataByEndpoint(
             `/api/option-chain-v3?type=Indices` +
             `&symbol=${encodeURIComponent(indexSymbol.toUpperCase())}` +
@@ -394,7 +553,7 @@ export class NseIndia {
             `&symbol=${encodeURIComponent(symbol.toUpperCase())}`
         )
     }
-    
+
     /**
          * 
          * @param symbol 
@@ -525,7 +684,7 @@ export class NseIndia {
      * @returns Promise<TechnicalIndicators>
      */
     async getTechnicalIndicators(
-        symbol: string, 
+        symbol: string,
         period = 200,
         options: {
             smaPeriods?: number[] // Array of periods for SMA (e.g., [5, 10, 20, 50])
@@ -578,6 +737,9 @@ export type {
     PreOpenMarketData,
     MergedDailyReportsData,
     TechnicalIndicators,
+    ChartingSymbolInfo,
+    ChartingOHLCItem,
+    ChartingOHLCResponse,
     // Nested interfaces
     EquityInfo,
     EquityMetadata,

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -9,6 +9,40 @@ export interface IntradayData {
     closePrice: number
 }
 /**
+ * Symbol information returned by the charting.nseindia.com symbolsDynamic API.
+ * The `scripCode` field is what the historical chart API refers to as `token`.
+ */
+export interface ChartingSymbolInfo {
+    symbol: string
+    scripCode: string   // This is the "token" required by the historical chart API
+    companyName: string
+    isin: string
+    segment: string
+    series: string
+    status: string
+}
+
+/**
+ * Individual candle data point from charting API
+ */
+export interface ChartingOHLCItem {
+    volume: number
+    high: number
+    low: number
+    time: number     // Unix timestamp in milliseconds
+    close: number
+    open: number
+}
+
+/**
+ * Response structure for historical chart OHLC data
+ */
+export interface ChartingOHLCResponse {
+    status: boolean
+    data: ChartingOHLCItem[]
+}
+
+/**
  * Date range for historical data queries
  */
 export interface DateRange {

--- a/src/mcp/mcp-tools.ts
+++ b/src/mcp/mcp-tools.ts
@@ -406,7 +406,8 @@ export const mcpTools = [
         },
         token: {
           type: 'string',
-          description: 'NSE script code (token / scripCode) for the symbol. If omitted, it is looked up automatically via get_equity_chart_symbol_info.',
+          description: 'NSE script code (token / scripCode) for the symbol. ' +
+                       'If omitted, it is looked up automatically via get_equity_chart_symbol_info.',
         },
         symbol_type: {
           type: 'string',

--- a/src/mcp/mcp-tools.ts
+++ b/src/mcp/mcp-tools.ts
@@ -386,6 +386,64 @@ export const mcpTools = [
       required: ['index_symbol'],
     },
   },
+  {
+    name: 'get_equity_chart_historical_data',
+    description: 'Get historical chart data from charting.nseindia.com for equity symbols with OHLC candle data',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        symbol: {
+          type: 'string',
+          description: 'Equity symbol with series code (e.g., ONGC-EQ, TCS-EQ)',
+        },
+        from_date: {
+          type: 'string',
+          description: 'Unix timestamp for start date (e.g., 1775834999)',
+        },
+        to_date: {
+          type: 'string',
+          description: 'Unix timestamp for end date (e.g., 1775999513)',
+        },
+        token: {
+          type: 'string',
+          description: 'NSE script code (token / scripCode) for the symbol. If omitted, it is looked up automatically via get_equity_chart_symbol_info.',
+        },
+        symbol_type: {
+          type: 'string',
+          description: 'Type of symbol - Equity or Index (default: Equity)',
+        },
+        chart_type: {
+          type: 'string',
+          description: 'Chart type - I for intraday, D for daily (default: I)',
+        },
+        time_interval: {
+          type: 'string',
+          description: 'Time interval in minutes - 1, 5, 15, 30, 60. (default: 5)',
+        },
+      },
+      required: ['symbol', 'from_date', 'to_date'],
+    },
+  },
+  {
+    name: 'get_equity_chart_symbol_info',
+    description:
+      'Look up NSE charting symbol information for an equity symbol. Returns scripCode (token) ' +
+      'needed by get_equity_chart_historical_data. Call this first when you do not already know the token.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        symbol: {
+          type: 'string',
+          description: 'Equity symbol with or without series code (e.g., ONGC-EQ or ONGC)',
+        },
+        segment: {
+          type: 'string',
+          description: 'Optional market segment filter. Leave empty to search all segments.',
+        },
+      },
+      required: ['symbol'],
+    },
+  },
 ]
 
 // Common tool call handler function
@@ -397,421 +455,466 @@ export async function handleMCPToolCall(
   let result: unknown
 
   switch (name) {
-          case 'get_all_stock_symbols': {
-        result = await nseClient.getAllStockSymbols()
-        break
+    case 'get_all_stock_symbols': {
+      result = await nseClient.getAllStockSymbols()
+      break
+    }
+
+    case 'get_equity_details': {
+      if (!args?.symbol || typeof args.symbol !== 'string') {
+        throw new Error('Symbol parameter is required and must be a string')
+      }
+      result = await nseClient.getEquityDetails(args.symbol)
+      break
+    }
+
+    case 'get_equity_trade_info': {
+      if (!args?.symbol || typeof args.symbol !== 'string') {
+        throw new Error('Symbol parameter is required and must be a string')
+      }
+      result = await nseClient.getEquityTradeInfo(args.symbol)
+      break
+    }
+
+    case 'get_equity_corporate_info': {
+      if (!args?.symbol || typeof args.symbol !== 'string') {
+        throw new Error('Symbol parameter is required and must be a string')
+      }
+      result = await nseClient.getEquityCorporateInfo(args.symbol)
+      break
+    }
+
+    case 'get_equity_intraday_data': {
+      if (!args?.symbol || typeof args.symbol !== 'string') {
+        throw new Error('Symbol parameter is required and must be a string')
+      }
+      result = await nseClient.getEquityIntradayData(args.symbol)
+      break
+    }
+
+    case 'get_equity_historical_data': {
+      if (!args?.symbol || typeof args.symbol !== 'string') {
+        throw new Error('Symbol parameter is required and must be a string')
+      }
+      const range = args.start_date && args.end_date &&
+        typeof args.start_date === 'string' &&
+        typeof args.end_date === 'string'
+        ? { start: new Date(args.start_date), end: new Date(args.end_date) }
+        : undefined
+      result = await nseClient.getEquityHistoricalData(args.symbol, range)
+      break
+    }
+
+    case 'get_equity_series': {
+      if (!args?.symbol || typeof args.symbol !== 'string') {
+        throw new Error('Symbol parameter is required and must be a string')
+      }
+      result = await nseClient.getEquitySeries(args.symbol)
+      break
+    }
+
+    case 'get_equity_stock_indices': {
+      if (!args?.index || typeof args.index !== 'string') {
+        throw new Error('Index parameter is required and must be a string')
+      }
+      result = await nseClient.getEquityStockIndices(args.index)
+      break
+    }
+
+    case 'get_index_intraday_data': {
+      if (!args?.index || typeof args.index !== 'string') {
+        throw new Error('Index parameter is required and must be a string')
+      }
+      result = await nseClient.getIndexIntradayData(args.index)
+      break
+    }
+
+    case 'get_index_option_chain': {
+      if (!args?.index_symbol || typeof args.index_symbol !== 'string') {
+        throw new Error('Index symbol parameter is required and must be a string')
+      }
+      result = await nseClient.getIndexOptionChain(args.index_symbol)
+      break
+    }
+
+    case 'get_index_option_chain_contract_info': {
+      if (!args?.index_symbol || typeof args.index_symbol !== 'string') {
+        throw new Error('Index symbol parameter is required and must be a string')
+      }
+      result = await nseClient.getIndexOptionChainContractInfo(args.index_symbol)
+      break
+    }
+
+    case 'get_equity_option_chain': {
+      if (!args?.symbol || typeof args.symbol !== 'string') {
+        throw new Error('Symbol parameter is required and must be a string')
+      }
+      result = await nseClient.getEquityOptionChain(args.symbol)
+      break
+    }
+
+    case 'get_commodity_option_chain': {
+      if (!args?.symbol || typeof args.symbol !== 'string') {
+        throw new Error('Symbol parameter is required and must be a string')
+      }
+      result = await nseClient.getCommodityOptionChain(args.symbol)
+      break
+    }
+
+    case 'get_glossary': {
+      result = await nseClient.getGlossary()
+      break
+    }
+
+    case 'get_trading_holidays': {
+      result = await nseClient.getTradingHolidays()
+      break
+    }
+
+    case 'get_clearing_holidays': {
+      result = await nseClient.getClearingHolidays()
+      break
+    }
+
+    case 'get_market_status': {
+      result = await nseClient.getMarketStatus()
+      break
+    }
+
+    case 'get_market_turnover': {
+      result = await nseClient.getMarketTurnover()
+      break
+    }
+
+    case 'get_all_indices': {
+      result = await nseClient.getAllIndices()
+      break
+    }
+
+    case 'get_index_names': {
+      result = await nseClient.getIndexNames()
+      break
+    }
+
+    case 'get_circulars': {
+      result = await nseClient.getCirculars()
+      break
+    }
+
+    case 'get_latest_circulars': {
+      result = await nseClient.getLatestCirculars()
+      break
+    }
+
+    case 'get_equity_master': {
+      result = await nseClient.getEquityMaster()
+      break
+    }
+
+    case 'get_pre_open_market_data': {
+      result = await nseClient.getPreOpenMarketData()
+      break
+    }
+
+    case 'get_merged_daily_reports_capital': {
+      result = await nseClient.getMergedDailyReportsCapital()
+      break
+    }
+
+    case 'get_merged_daily_reports_derivatives': {
+      result = await nseClient.getMergedDailyReportsDerivatives()
+      break
+    }
+
+    case 'get_merged_daily_reports_debt': {
+      result = await nseClient.getMergedDailyReportsDebt()
+      break
+    }
+
+    case 'get_equity_technical_indicators': {
+      if (!args?.symbol || typeof args.symbol !== 'string') {
+        throw new Error('Symbol parameter is required and must be a string')
       }
 
-      case 'get_equity_details': {
-        if (!args?.symbol || typeof args.symbol !== 'string') {
-          throw new Error('Symbol parameter is required and must be a string')
-        }
-        result = await nseClient.getEquityDetails(args.symbol)
-        break
+      const options: Record<string, unknown> = {}
+      const showOnlyLatest = args.show_only_latest !== undefined
+        ? args.show_only_latest
+        : true
+
+      if (args.period && typeof args.period === 'number') {
+        options.period = args.period
       }
 
-      case 'get_equity_trade_info': {
-        if (!args?.symbol || typeof args.symbol !== 'string') {
-          throw new Error('Symbol parameter is required and must be a string')
-        }
-        result = await nseClient.getEquityTradeInfo(args.symbol)
-        break
+      if (args.sma_periods && Array.isArray(args.sma_periods)) {
+        options.smaPeriods = args.sma_periods
       }
 
-      case 'get_equity_corporate_info': {
-        if (!args?.symbol || typeof args.symbol !== 'string') {
-          throw new Error('Symbol parameter is required and must be a string')
-        }
-        result = await nseClient.getEquityCorporateInfo(args.symbol)
-        break
+      if (args.ema_periods && Array.isArray(args.ema_periods)) {
+        options.emaPeriods = args.ema_periods
       }
 
-          case 'get_equity_intraday_data': {
-        if (!args?.symbol || typeof args.symbol !== 'string') {
-          throw new Error('Symbol parameter is required and must be a string')
-        }
-        result = await nseClient.getEquityIntradayData(args.symbol)
-        break
+      if (args.rsi_period && typeof args.rsi_period === 'number') {
+        options.rsiPeriod = args.rsi_period
       }
 
-          case 'get_equity_historical_data': {
-        if (!args?.symbol || typeof args.symbol !== 'string') {
-          throw new Error('Symbol parameter is required and must be a string')
-        }
-        const range = args.start_date && args.end_date && 
-          typeof args.start_date === 'string' && 
-          typeof args.end_date === 'string'
-          ? { start: new Date(args.start_date), end: new Date(args.end_date) }
-          : undefined
-        result = await nseClient.getEquityHistoricalData(args.symbol, range)
-        break
+      if (args.bb_period && typeof args.bb_period === 'number') {
+        options.bbPeriod = args.bb_period
       }
 
-          case 'get_equity_series': {
-        if (!args?.symbol || typeof args.symbol !== 'string') {
-          throw new Error('Symbol parameter is required and must be a string')
-        }
-        result = await nseClient.getEquitySeries(args.symbol)
-        break
+      if (args.bb_std_dev && typeof args.bb_std_dev === 'number') {
+        options.bbStdDev = args.bb_std_dev
       }
 
-      case 'get_equity_stock_indices': {
-        if (!args?.index || typeof args.index !== 'string') {
-          throw new Error('Index parameter is required and must be a string')
-        }
-        result = await nseClient.getEquityStockIndices(args.index)
-        break
+      const indicators = await nseClient.getTechnicalIndicators(
+        args.symbol,
+        (options.period as number) || 200,
+        options
+      )
+
+      // Helper function to round numbers to 2 decimal places
+      const roundTo2Decimals = (value: number | null | undefined): number | null => {
+        return value !== null && value !== undefined ? Math.round(value * 100) / 100 : null
       }
 
-          case 'get_index_intraday_data': {
-        if (!args?.index || typeof args.index !== 'string') {
-          throw new Error('Index parameter is required and must be a string')
-        }
-        result = await nseClient.getIndexIntradayData(args.index)
-        break
+      // Helper function to round array of numbers to 2 decimal places
+      const roundArrayTo2Decimals = (arr: number[]): number[] => {
+        return arr.map(value => roundTo2Decimals(value) ?? 0)
       }
 
-      case 'get_index_option_chain': {
-        if (!args?.index_symbol || typeof args.index_symbol !== 'string') {
-          throw new Error('Index symbol parameter is required and must be a string')
-        }
-        result = await nseClient.getIndexOptionChain(args.index_symbol)
-        break
-      }
+      if (showOnlyLatest) {
+        // Return only the latest values
+        const latestIndicators: Record<string, unknown> = {}
 
-      case 'get_index_option_chain_contract_info': {
-        if (!args?.index_symbol || typeof args.index_symbol !== 'string') {
-          throw new Error('Index symbol parameter is required and must be a string')
-        }
-        result = await nseClient.getIndexOptionChainContractInfo(args.index_symbol)
-        break
-      }
+        // Process SMA indicators
+        latestIndicators.sma = {}
+        Object.keys(indicators.sma).forEach(key => {
+          const values = indicators.sma[key]
+            ; (latestIndicators.sma as Record<string, unknown>)[key] =
+              values.length > 0 ? roundTo2Decimals(values[values.length - 1]) : null
+        })
 
-      case 'get_equity_option_chain': {
-        if (!args?.symbol || typeof args.symbol !== 'string') {
-          throw new Error('Symbol parameter is required and must be a string')
-        }
-        result = await nseClient.getEquityOptionChain(args.symbol)
-        break
-      }
+        // Process EMA indicators
+        latestIndicators.ema = {}
+        Object.keys(indicators.ema).forEach(key => {
+          const values = indicators.ema[key]
+            ; (latestIndicators.ema as Record<string, unknown>)[key] =
+              values.length > 0 ? roundTo2Decimals(values[values.length - 1]) : null
+        })
 
-      case 'get_commodity_option_chain': {
-        if (!args?.symbol || typeof args.symbol !== 'string') {
-          throw new Error('Symbol parameter is required and must be a string')
-        }
-        result = await nseClient.getCommodityOptionChain(args.symbol)
-        break
-      }
-
-      case 'get_glossary': {
-        result = await nseClient.getGlossary()
-        break
-      }
-
-      case 'get_trading_holidays': {
-        result = await nseClient.getTradingHolidays()
-        break
-      }
-
-      case 'get_clearing_holidays': {
-        result = await nseClient.getClearingHolidays()
-        break
-      }
-
-      case 'get_market_status': {
-        result = await nseClient.getMarketStatus()
-        break
-      }
-
-      case 'get_market_turnover': {
-        result = await nseClient.getMarketTurnover()
-        break
-      }
-
-      case 'get_all_indices': {
-        result = await nseClient.getAllIndices()
-        break
-      }
-
-      case 'get_index_names': {
-        result = await nseClient.getIndexNames()
-        break
-      }
-
-      case 'get_circulars': {
-        result = await nseClient.getCirculars()
-        break
-      }
-
-      case 'get_latest_circulars': {
-        result = await nseClient.getLatestCirculars()
-        break
-      }
-
-      case 'get_equity_master': {
-        result = await nseClient.getEquityMaster()
-        break
-      }
-
-      case 'get_pre_open_market_data': {
-        result = await nseClient.getPreOpenMarketData()
-        break
-      }
-
-      case 'get_merged_daily_reports_capital': {
-        result = await nseClient.getMergedDailyReportsCapital()
-        break
-      }
-
-      case 'get_merged_daily_reports_derivatives': {
-        result = await nseClient.getMergedDailyReportsDerivatives()
-        break
-      }
-
-      case 'get_merged_daily_reports_debt': {
-        result = await nseClient.getMergedDailyReportsDebt()
-        break
-      }
-
-      case 'get_equity_technical_indicators': {
-        if (!args?.symbol || typeof args.symbol !== 'string') {
-          throw new Error('Symbol parameter is required and must be a string')
-        }
-        
-        const options: Record<string, unknown> = {}
-        const showOnlyLatest = args.show_only_latest !== undefined 
-          ? args.show_only_latest 
-          : true
-        
-        if (args.period && typeof args.period === 'number') {
-          options.period = args.period
-        }
-        
-        if (args.sma_periods && Array.isArray(args.sma_periods)) {
-          options.smaPeriods = args.sma_periods
-        }
-        
-        if (args.ema_periods && Array.isArray(args.ema_periods)) {
-          options.emaPeriods = args.ema_periods
-        }
-        
-        if (args.rsi_period && typeof args.rsi_period === 'number') {
-          options.rsiPeriod = args.rsi_period
-        }
-        
-        if (args.bb_period && typeof args.bb_period === 'number') {
-          options.bbPeriod = args.bb_period
-        }
-        
-        if (args.bb_std_dev && typeof args.bb_std_dev === 'number') {
-          options.bbStdDev = args.bb_std_dev
-        }
-        
-        const indicators = await nseClient.getTechnicalIndicators(
-          args.symbol, 
-          (options.period as number) || 200, 
-          options
+        // Process other indicators
+        latestIndicators.rsi = roundTo2Decimals(
+          indicators.rsi.length > 0
+            ? indicators.rsi[indicators.rsi.length - 1]
+            : null
         )
-        
-        // Helper function to round numbers to 2 decimal places
-        const roundTo2Decimals = (value: number | null | undefined): number | null => {
-          return value !== null && value !== undefined ? Math.round(value * 100) / 100 : null
+        latestIndicators.macd = {
+          macd: roundTo2Decimals(
+            indicators.macd.macd.length > 0
+              ? indicators.macd.macd[indicators.macd.macd.length - 1]
+              : null
+          ),
+          signal: roundTo2Decimals(
+            indicators.macd.signal.length > 0
+              ? indicators.macd.signal[indicators.macd.signal.length - 1]
+              : null
+          ),
+          histogram: roundTo2Decimals(
+            indicators.macd.histogram.length > 0
+              ? indicators.macd.histogram[indicators.macd.histogram.length - 1]
+              : null
+          )
         }
+        latestIndicators.bollingerBands = {
+          upper: roundTo2Decimals(
+            indicators.bollingerBands.upper.length > 0
+              ? indicators.bollingerBands.upper[indicators.bollingerBands.upper.length - 1]
+              : null
+          ),
+          middle: roundTo2Decimals(
+            indicators.bollingerBands.middle.length > 0
+              ? indicators.bollingerBands.middle[indicators.bollingerBands.middle.length - 1]
+              : null
+          ),
+          lower: roundTo2Decimals(
+            indicators.bollingerBands.lower.length > 0
+              ? indicators.bollingerBands.lower[indicators.bollingerBands.lower.length - 1]
+              : null
+          )
+        }
+        latestIndicators.stochastic = {
+          k: roundTo2Decimals(
+            indicators.stochastic.k.length > 0
+              ? indicators.stochastic.k[indicators.stochastic.k.length - 1]
+              : null
+          ),
+          d: roundTo2Decimals(
+            indicators.stochastic.d.length > 0
+              ? indicators.stochastic.d[indicators.stochastic.d.length - 1]
+              : null
+          )
+        }
+        latestIndicators.williamsR = roundTo2Decimals(
+          indicators.williamsR.length > 0
+            ? indicators.williamsR[indicators.williamsR.length - 1]
+            : null
+        )
+        latestIndicators.atr = roundTo2Decimals(
+          indicators.atr.length > 0
+            ? indicators.atr[indicators.atr.length - 1]
+            : null
+        )
+        latestIndicators.adx = roundTo2Decimals(
+          indicators.adx.length > 0
+            ? indicators.adx[indicators.adx.length - 1]
+            : null
+        )
+        latestIndicators.obv = roundTo2Decimals(
+          indicators.obv.length > 0
+            ? indicators.obv[indicators.obv.length - 1]
+            : null
+        )
+        latestIndicators.cci = roundTo2Decimals(
+          indicators.cci.length > 0
+            ? indicators.cci[indicators.cci.length - 1]
+            : null
+        )
+        latestIndicators.mfi = roundTo2Decimals(
+          indicators.mfi.length > 0
+            ? indicators.mfi[indicators.mfi.length - 1]
+            : null
+        )
+        latestIndicators.roc = roundTo2Decimals(
+          indicators.roc.length > 0
+            ? indicators.roc[indicators.roc.length - 1]
+            : null
+        )
+        latestIndicators.momentum = roundTo2Decimals(
+          indicators.momentum.length > 0
+            ? indicators.momentum[indicators.momentum.length - 1]
+            : null
+        )
+        latestIndicators.ad = roundTo2Decimals(
+          indicators.ad.length > 0
+            ? indicators.ad[indicators.ad.length - 1]
+            : null
+        )
+        latestIndicators.vwap = roundTo2Decimals(
+          indicators.vwap.length > 0
+            ? indicators.vwap[indicators.vwap.length - 1]
+            : null
+        )
 
-        // Helper function to round array of numbers to 2 decimal places
-        const roundArrayTo2Decimals = (arr: number[]): number[] => {
-          return arr.map(value => roundTo2Decimals(value) ?? 0)
+        result = latestIndicators
+      } else {
+        // Return all values with 2 decimal precision
+        const roundedIndicators: Record<string, unknown> = {}
+
+        // Process SMA indicators
+        roundedIndicators.sma = {}
+        Object.keys(indicators.sma).forEach(key => {
+          (roundedIndicators.sma as Record<string, unknown>)[key] =
+            roundArrayTo2Decimals(indicators.sma[key])
+        })
+
+        // Process EMA indicators
+        roundedIndicators.ema = {}
+        Object.keys(indicators.ema).forEach(key => {
+          (roundedIndicators.ema as Record<string, unknown>)[key] =
+            roundArrayTo2Decimals(indicators.ema[key])
+        })
+
+        // Process other indicators
+        roundedIndicators.rsi = roundArrayTo2Decimals(indicators.rsi)
+        roundedIndicators.macd = {
+          macd: roundArrayTo2Decimals(indicators.macd.macd),
+          signal: roundArrayTo2Decimals(indicators.macd.signal),
+          histogram: roundArrayTo2Decimals(indicators.macd.histogram)
         }
-        
-        if (showOnlyLatest) {
-          // Return only the latest values
-          const latestIndicators: Record<string, unknown> = {}
-          
-          // Process SMA indicators
-          latestIndicators.sma = {}
-          Object.keys(indicators.sma).forEach(key => {
-            const values = indicators.sma[key]
-            ;(latestIndicators.sma as Record<string, unknown>)[key] = 
-              values.length > 0 ? roundTo2Decimals(values[values.length - 1]) : null
-          })
-          
-          // Process EMA indicators
-          latestIndicators.ema = {}
-          Object.keys(indicators.ema).forEach(key => {
-            const values = indicators.ema[key]
-            ;(latestIndicators.ema as Record<string, unknown>)[key] = 
-              values.length > 0 ? roundTo2Decimals(values[values.length - 1]) : null
-          })
-          
-          // Process other indicators
-          latestIndicators.rsi = roundTo2Decimals(
-            indicators.rsi.length > 0 
-              ? indicators.rsi[indicators.rsi.length - 1] 
-              : null
-          )
-          latestIndicators.macd = {
-            macd: roundTo2Decimals(
-              indicators.macd.macd.length > 0 
-                ? indicators.macd.macd[indicators.macd.macd.length - 1] 
-                : null
-            ),
-            signal: roundTo2Decimals(
-              indicators.macd.signal.length > 0 
-                ? indicators.macd.signal[indicators.macd.signal.length - 1] 
-                : null
-            ),
-            histogram: roundTo2Decimals(
-              indicators.macd.histogram.length > 0 
-                ? indicators.macd.histogram[indicators.macd.histogram.length - 1] 
-                : null
-            )
-          }
-          latestIndicators.bollingerBands = {
-            upper: roundTo2Decimals(
-              indicators.bollingerBands.upper.length > 0 
-                ? indicators.bollingerBands.upper[indicators.bollingerBands.upper.length - 1] 
-                : null
-            ),
-            middle: roundTo2Decimals(
-              indicators.bollingerBands.middle.length > 0 
-                ? indicators.bollingerBands.middle[indicators.bollingerBands.middle.length - 1] 
-                : null
-            ),
-            lower: roundTo2Decimals(
-              indicators.bollingerBands.lower.length > 0 
-                ? indicators.bollingerBands.lower[indicators.bollingerBands.lower.length - 1] 
-                : null
-            )
-          }
-          latestIndicators.stochastic = {
-            k: roundTo2Decimals(
-              indicators.stochastic.k.length > 0 
-                ? indicators.stochastic.k[indicators.stochastic.k.length - 1] 
-                : null
-            ),
-            d: roundTo2Decimals(
-              indicators.stochastic.d.length > 0 
-                ? indicators.stochastic.d[indicators.stochastic.d.length - 1] 
-                : null
-            )
-          }
-          latestIndicators.williamsR = roundTo2Decimals(
-            indicators.williamsR.length > 0 
-              ? indicators.williamsR[indicators.williamsR.length - 1] 
-              : null
-          )
-          latestIndicators.atr = roundTo2Decimals(
-            indicators.atr.length > 0 
-              ? indicators.atr[indicators.atr.length - 1] 
-              : null
-          )
-          latestIndicators.adx = roundTo2Decimals(
-            indicators.adx.length > 0 
-              ? indicators.adx[indicators.adx.length - 1] 
-              : null
-          )
-          latestIndicators.obv = roundTo2Decimals(
-            indicators.obv.length > 0 
-              ? indicators.obv[indicators.obv.length - 1] 
-              : null
-          )
-          latestIndicators.cci = roundTo2Decimals(
-            indicators.cci.length > 0 
-              ? indicators.cci[indicators.cci.length - 1] 
-              : null
-          )
-          latestIndicators.mfi = roundTo2Decimals(
-            indicators.mfi.length > 0 
-              ? indicators.mfi[indicators.mfi.length - 1] 
-              : null
-          )
-          latestIndicators.roc = roundTo2Decimals(
-            indicators.roc.length > 0 
-              ? indicators.roc[indicators.roc.length - 1] 
-              : null
-          )
-          latestIndicators.momentum = roundTo2Decimals(
-            indicators.momentum.length > 0 
-              ? indicators.momentum[indicators.momentum.length - 1] 
-              : null
-          )
-          latestIndicators.ad = roundTo2Decimals(
-            indicators.ad.length > 0 
-              ? indicators.ad[indicators.ad.length - 1] 
-              : null
-          )
-          latestIndicators.vwap = roundTo2Decimals(
-            indicators.vwap.length > 0 
-              ? indicators.vwap[indicators.vwap.length - 1] 
-              : null
-          )
-          
-          result = latestIndicators
-        } else {
-          // Return all values with 2 decimal precision
-          const roundedIndicators: Record<string, unknown> = {}
-          
-          // Process SMA indicators
-          roundedIndicators.sma = {}
-          Object.keys(indicators.sma).forEach(key => {
-            (roundedIndicators.sma as Record<string, unknown>)[key] = 
-              roundArrayTo2Decimals(indicators.sma[key])
-          })
-          
-          // Process EMA indicators
-          roundedIndicators.ema = {}
-          Object.keys(indicators.ema).forEach(key => {
-            (roundedIndicators.ema as Record<string, unknown>)[key] = 
-              roundArrayTo2Decimals(indicators.ema[key])
-          })
-          
-          // Process other indicators
-          roundedIndicators.rsi = roundArrayTo2Decimals(indicators.rsi)
-          roundedIndicators.macd = {
-            macd: roundArrayTo2Decimals(indicators.macd.macd),
-            signal: roundArrayTo2Decimals(indicators.macd.signal),
-            histogram: roundArrayTo2Decimals(indicators.macd.histogram)
-          }
-          roundedIndicators.bollingerBands = {
-            upper: roundArrayTo2Decimals(indicators.bollingerBands.upper),
-            middle: roundArrayTo2Decimals(indicators.bollingerBands.middle),
-            lower: roundArrayTo2Decimals(indicators.bollingerBands.lower)
-          }
-          roundedIndicators.stochastic = {
-            k: roundArrayTo2Decimals(indicators.stochastic.k),
-            d: roundArrayTo2Decimals(indicators.stochastic.d)
-          }
-          roundedIndicators.williamsR = roundArrayTo2Decimals(indicators.williamsR)
-          roundedIndicators.atr = roundArrayTo2Decimals(indicators.atr)
-          roundedIndicators.adx = roundArrayTo2Decimals(indicators.adx)
-          roundedIndicators.obv = roundArrayTo2Decimals(indicators.obv)
-          roundedIndicators.cci = roundArrayTo2Decimals(indicators.cci)
-          roundedIndicators.mfi = roundArrayTo2Decimals(indicators.mfi)
-          roundedIndicators.roc = roundArrayTo2Decimals(indicators.roc)
-          roundedIndicators.momentum = roundArrayTo2Decimals(indicators.momentum)
-          roundedIndicators.ad = roundArrayTo2Decimals(indicators.ad)
-          roundedIndicators.vwap = roundArrayTo2Decimals(indicators.vwap)
-          
-          result = roundedIndicators
+        roundedIndicators.bollingerBands = {
+          upper: roundArrayTo2Decimals(indicators.bollingerBands.upper),
+          middle: roundArrayTo2Decimals(indicators.bollingerBands.middle),
+          lower: roundArrayTo2Decimals(indicators.bollingerBands.lower)
         }
-        break
+        roundedIndicators.stochastic = {
+          k: roundArrayTo2Decimals(indicators.stochastic.k),
+          d: roundArrayTo2Decimals(indicators.stochastic.d)
+        }
+        roundedIndicators.williamsR = roundArrayTo2Decimals(indicators.williamsR)
+        roundedIndicators.atr = roundArrayTo2Decimals(indicators.atr)
+        roundedIndicators.adx = roundArrayTo2Decimals(indicators.adx)
+        roundedIndicators.obv = roundArrayTo2Decimals(indicators.obv)
+        roundedIndicators.cci = roundArrayTo2Decimals(indicators.cci)
+        roundedIndicators.mfi = roundArrayTo2Decimals(indicators.mfi)
+        roundedIndicators.roc = roundArrayTo2Decimals(indicators.roc)
+        roundedIndicators.momentum = roundArrayTo2Decimals(indicators.momentum)
+        roundedIndicators.ad = roundArrayTo2Decimals(indicators.ad)
+        roundedIndicators.vwap = roundArrayTo2Decimals(indicators.vwap)
+
+        result = roundedIndicators
+      }
+      break
+    }
+
+    case 'get_gainers_and_losers_by_index': {
+      if (!args?.index_symbol || typeof args.index_symbol !== 'string') {
+        throw new Error('Index symbol parameter is required and must be a string')
+      }
+      result = await getGainersAndLosersByIndex(args.index_symbol)
+      break
+    }
+
+    case 'get_most_active_equities': {
+      if (!args?.index_symbol || typeof args.index_symbol !== 'string') {
+        throw new Error('Index symbol parameter is required and must be a string')
+      }
+      result = await getMostActiveEquities(args.index_symbol)
+      break
+    }
+
+    case 'get_equity_chart_historical_data': {
+      if (!args?.symbol || typeof args.symbol !== 'string') {
+        throw new Error('Symbol parameter is required and must be a string')
+      }
+      if (!args?.from_date || typeof args.from_date !== 'string') {
+        throw new Error('from_date parameter is required and must be a string (unix timestamp)')
+      }
+      if (!args?.to_date || typeof args.to_date !== 'string') {
+        throw new Error('to_date parameter is required and must be a string (unix timestamp)')
       }
 
-      case 'get_gainers_and_losers_by_index': {
-        if (!args?.index_symbol || typeof args.index_symbol !== 'string') {
-          throw new Error('Index symbol parameter is required and must be a string')
-        }
-        result = await getGainersAndLosersByIndex(args.index_symbol)
-        break
-      }
+      // token is now optional — the core method auto-fetches it via getEquitySymbolInfo
+      const token = args.token && typeof args.token === 'string' ? args.token : undefined
 
-      case 'get_most_active_equities': {
-        if (!args?.index_symbol || typeof args.index_symbol !== 'string') {
-          throw new Error('Index symbol parameter is required and must be a string')
-        }
-        result = await getMostActiveEquities(args.index_symbol)
-        break
+      const symbolType = args.symbol_type && typeof args.symbol_type === 'string'
+        ? args.symbol_type
+        : 'Equity'
+      const chartType = args.chart_type && typeof args.chart_type === 'string'
+        ? args.chart_type
+        : 'I'
+      const timeInterval = args.time_interval && typeof args.time_interval === 'string'
+        ? args.time_interval
+        : '5'
+
+      result = await nseClient.getEquityChartHistoricalData(
+        args.symbol,
+        args.from_date,
+        args.to_date,
+        token,
+        symbolType,
+        chartType,
+        timeInterval
+      )
+      break
+    }
+
+    case 'get_equity_chart_symbol_info': {
+      if (!args?.symbol || typeof args.symbol !== 'string') {
+        throw new Error('Symbol parameter is required and must be a string')
       }
+      const segment = args.segment && typeof args.segment === 'string' ? args.segment : ''
+      result = await nseClient.getEquitySymbolInfo(args.symbol, segment)
+      break
+    }
 
     default:
       throw new Error(`Unknown tool: ${name}`)

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -7,7 +7,7 @@ import {
 } from './helpers'
 import { mcpClient, MCPClientRequest, MCPClient } from './mcp/client/mcp-client.js'
 
-const mainRouter:Router = Router()
+const mainRouter: Router = Router()
 
 const nseIndia = new NseIndia()
 
@@ -27,7 +27,7 @@ const nseIndia = new NseIndia()
  *       400:
  *         description: Returns a JSON error object of API call
  */
- mainRouter.get('/', async (_req, res) => {
+mainRouter.get('/', async (_req, res) => {
     try {
         res.json(await nseIndia.getDataByEndpoint(ApiList.MARKET_STATUS))
     } catch (error) {
@@ -767,48 +767,48 @@ mainRouter.get('/api/equity/historical/:symbol', async (req, res) => {
 mainRouter.get('/api/equity/technicalIndicators/:symbol', async (req, res) => {
     try {
         const { symbol } = req.params
-        const { 
-            period, 
-            smaPeriods, 
-            emaPeriods, 
-            rsiPeriod, 
-            bbPeriod, 
+        const {
+            period,
+            smaPeriods,
+            emaPeriods,
+            rsiPeriod,
+            bbPeriod,
             bbStdDev,
             showOnlyLatest
         } = req.query
 
         // Parse query parameters
         const options: any = {}
-        
+
         if (period) {
             options.period = parseInt(period as string)
         }
-        
+
         if (smaPeriods) {
             options.smaPeriods = (smaPeriods as string).split(',').map(p => parseInt(p.trim()))
         }
-        
+
         if (emaPeriods) {
             options.emaPeriods = (emaPeriods as string).split(',').map(p => parseInt(p.trim()))
         }
-        
+
         if (rsiPeriod) {
             options.rsiPeriod = parseInt(rsiPeriod as string)
         }
-        
+
         if (bbPeriod) {
             options.bbPeriod = parseInt(bbPeriod as string)
         }
-        
+
         if (bbStdDev) {
             options.bbStdDev = parseFloat(bbStdDev as string)
         }
 
         const indicators = await nseIndia.getTechnicalIndicators(symbol, (options.period as number) || 200, options)
-        
+
         // Parse showOnlyLatest flag (default: true)
         const showLatest = showOnlyLatest === undefined || showOnlyLatest === 'true'
-        
+
         // Helper function to round numbers to 2 decimal places
         const roundTo2Decimals = (value: number | null): number | null => {
             return value !== null ? Math.round(value * 100) / 100 : null
@@ -822,21 +822,21 @@ mainRouter.get('/api/equity/technicalIndicators/:symbol', async (req, res) => {
         if (showLatest) {
             // Return only the latest values
             const latestIndicators: any = {}
-            
+
             // Process SMA indicators
             latestIndicators.sma = {}
             Object.keys(indicators.sma).forEach(key => {
                 const values = indicators.sma[key]
                 latestIndicators.sma[key] = values.length > 0 ? roundTo2Decimals(values[values.length - 1]) : null
             })
-            
+
             // Process EMA indicators
             latestIndicators.ema = {}
             Object.keys(indicators.ema).forEach(key => {
                 const values = indicators.ema[key]
                 latestIndicators.ema[key] = values.length > 0 ? roundTo2Decimals(values[values.length - 1]) : null
             })
-            
+
             // Process other indicators
             latestIndicators.rsi = roundTo2Decimals(
                 indicators.rsi.length > 0 ? indicators.rsi[indicators.rsi.length - 1] : null
@@ -849,31 +849,31 @@ mainRouter.get('/api/equity/technicalIndicators/:symbol', async (req, res) => {
                     indicators.macd.signal.length > 0 ? indicators.macd.signal[indicators.macd.signal.length - 1] : null
                 ),
                 histogram: roundTo2Decimals(
-                    indicators.macd.histogram.length > 0 ? 
+                    indicators.macd.histogram.length > 0 ?
                         indicators.macd.histogram[indicators.macd.histogram.length - 1] : null
                 )
             }
             latestIndicators.bollingerBands = {
                 upper: roundTo2Decimals(
-                    indicators.bollingerBands.upper.length > 0 ? 
+                    indicators.bollingerBands.upper.length > 0 ?
                         indicators.bollingerBands.upper[indicators.bollingerBands.upper.length - 1] : null
                 ),
                 middle: roundTo2Decimals(
-                    indicators.bollingerBands.middle.length > 0 ? 
+                    indicators.bollingerBands.middle.length > 0 ?
                         indicators.bollingerBands.middle[indicators.bollingerBands.middle.length - 1] : null
                 ),
                 lower: roundTo2Decimals(
-                    indicators.bollingerBands.lower.length > 0 ? 
+                    indicators.bollingerBands.lower.length > 0 ?
                         indicators.bollingerBands.lower[indicators.bollingerBands.lower.length - 1] : null
                 )
             }
             latestIndicators.stochastic = {
                 k: roundTo2Decimals(
-                    indicators.stochastic.k.length > 0 ? 
+                    indicators.stochastic.k.length > 0 ?
                         indicators.stochastic.k[indicators.stochastic.k.length - 1] : null
                 ),
                 d: roundTo2Decimals(
-                    indicators.stochastic.d.length > 0 ? 
+                    indicators.stochastic.d.length > 0 ?
                         indicators.stochastic.d[indicators.stochastic.d.length - 1] : null
                 )
             }
@@ -907,24 +907,24 @@ mainRouter.get('/api/equity/technicalIndicators/:symbol', async (req, res) => {
             latestIndicators.vwap = roundTo2Decimals(
                 indicators.vwap.length > 0 ? indicators.vwap[indicators.vwap.length - 1] : null
             )
-            
+
             res.json(latestIndicators)
         } else {
             // Return all values with 2 decimal precision
             const roundedIndicators: any = {}
-            
+
             // Process SMA indicators
             roundedIndicators.sma = {}
             Object.keys(indicators.sma).forEach(key => {
                 roundedIndicators.sma[key] = roundArrayTo2Decimals(indicators.sma[key])
             })
-            
+
             // Process EMA indicators
             roundedIndicators.ema = {}
             Object.keys(indicators.ema).forEach(key => {
                 roundedIndicators.ema[key] = roundArrayTo2Decimals(indicators.ema[key])
             })
-            
+
             // Process other indicators
             roundedIndicators.rsi = roundArrayTo2Decimals(indicators.rsi)
             roundedIndicators.macd = {
@@ -951,7 +951,7 @@ mainRouter.get('/api/equity/technicalIndicators/:symbol', async (req, res) => {
             roundedIndicators.momentum = roundArrayTo2Decimals(indicators.momentum)
             roundedIndicators.ad = roundArrayTo2Decimals(indicators.ad)
             roundedIndicators.vwap = roundArrayTo2Decimals(indicators.vwap)
-            
+
             res.json(roundedIndicators)
         }
     } catch (error) {
@@ -1179,6 +1179,215 @@ mainRouter.get('/api/mostActive/:indexSymbol', async (req, res) => {
     }
 })
 
+/**
+ * @openapi
+ * /api/v1/charts/equity-historical-data:
+ *   get:
+ *     description: Get historical chart data from charting.nseindia.com for equity symbols
+ *     tags:
+ *       - Charting
+ *     produces:
+ *       - application/json
+ *     parameters:
+ *       - name: symbol
+ *         in: query
+ *         description: Equity symbol with series code (e.g., 'ONGC-EQ')
+ *         required: true
+ *         schema:
+ *           type: string
+ *           example: ONGC-EQ
+ *       - name: fromDate
+ *         in: query
+ *         description: Unix timestamp for start date
+ *         required: true
+ *         schema:
+ *           type: number
+ *           example: 1775834999
+ *       - name: toDate
+ *         in: query
+ *         description: Unix timestamp for end date
+ *         required: true
+ *         schema:
+ *           type: number
+ *           example: 1775999513
+ *       - name: token
+ *         in: query
+ *         description: Token value for charting API
+ *         required: true
+ *         schema:
+ *           type: string
+ *           example: "2475"
+ *       - name: symbolType
+ *         in: query
+ *         description: Type of symbol (e.g., 'Equity', 'Index')
+ *         required: false
+ *         schema:
+ *           type: string
+ *           default: Equity
+ *           example: Equity
+ *       - name: chartType
+ *         in: query
+ *         description: Chart type ('I' for intraday, 'D' for daily pattern, etc.)
+ *         required: false
+ *         schema:
+ *           type: string
+ *           default: I
+ *           example: I
+ *       - name: timeInterval
+ *         in: query
+ *         description: Time interval in minutes (e.g., '5', '15', '60')
+ *         required: false
+ *         schema:
+ *           type: string
+ *           default: "5"
+ *           example: "5"
+ *     responses:
+ *       200:
+ *         description: Returns historical chart data with OHLC values and timestamps
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: boolean
+ *                   description: true if request was successful
+ *                   example: true
+ *                 data:
+ *                   type: array
+ *                   description: Array of candle data points
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       volume:
+ *                         type: number
+ *                         example: 46151
+ *                       high:
+ *                         type: number
+ *                         example: 286.7
+ *                       low:
+ *                         type: number
+ *                         example: 286.3
+ *                       time:
+ *                         type: number
+ *                         description: Unix timestamp in milliseconds
+ *                         example: 1775834999000
+ *                       close:
+ *                         type: number
+ *                         example: 286.7
+ *                       open:
+ *                         type: number
+ *                         example: 286.65
+ *       400:
+ *         description: Returns error object if API call fails or parameters are invalid
+ */
+mainRouter.get('/api/v1/charts/equity-historical-data', async (req, res) => {
+    try {
+        const { symbol, fromDate, toDate, token, symbolType = 'Equity', chartType = 'I', timeInterval = '5' } = req.query
+
+        // Validate required parameters
+        if (!symbol) {
+            return res.status(400).json({ error: 'Missing required parameter: symbol' })
+        }
+        if (!fromDate) {
+            return res.status(400).json({ error: 'Missing required parameter: fromDate' })
+        }
+        if (!toDate) {
+            return res.status(400).json({ error: 'Missing required parameter: toDate' })
+        }
+        if (!token) {
+            return res.status(400).json({ error: 'Missing required parameter: token' })
+        }
+
+        // Call the charting method
+        const chartData = await nseIndia.getEquityChartHistoricalData(
+            String(symbol),
+            String(fromDate),
+            String(toDate),
+            String(token),
+            String(symbolType),
+            String(chartType),
+            String(timeInterval)
+        )
+
+        res.json(chartData)
+    } catch (error) {
+        res.status(400).json(error)
+    }
+})
+
+/**
+ * @openapi
+ * /api/v1/charts/symbol-info:
+ *   get:
+ *     description: >
+ *       Look up NSE charting symbol information (including scripCode / token) for a
+ *       given equity symbol. The returned `scripCode` is the value that must be passed
+ *       as `token` to the `/api/v1/charts/equity-historical-data` endpoint.
+ *     tags:
+ *       - Charting
+ *     produces:
+ *       - application/json
+ *     parameters:
+ *       - name: symbol
+ *         in: query
+ *         description: Equity symbol with or without series code (e.g., 'ONGC-EQ' or 'ONGC')
+ *         required: true
+ *         schema:
+ *           type: string
+ *           example: ONGC-EQ
+ *       - name: segment
+ *         in: query
+ *         description: Optional market segment filter (leave empty to search all segments)
+ *         required: false
+ *         schema:
+ *           type: string
+ *           example: ''
+ *     responses:
+ *       200:
+ *         description: Returns charting symbol information including scripCode (token)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 symbol:
+ *                   type: string
+ *                   example: ONGC-EQ
+ *                 scripCode:
+ *                   type: string
+ *                   description: The token value required by the historical chart API
+ *                   example: "2475"
+ *                 companyName:
+ *                   type: string
+ *                 isin:
+ *                   type: string
+ *                 segment:
+ *                   type: string
+ *                 series:
+ *                   type: string
+ *                 status:
+ *                   type: string
+ *       400:
+ *         description: Returns error if symbol is missing or lookup fails
+ */
+mainRouter.get('/api/v1/charts/symbol-info', async (req, res) => {
+    try {
+        const { symbol, segment = '' } = req.query
+
+        if (!symbol) {
+            return res.status(400).json({ error: 'Missing required parameter: symbol' })
+        }
+
+        const symbolInfo = await nseIndia.getEquitySymbolInfo(String(symbol), String(segment))
+        res.json(symbolInfo)
+    } catch (error) {
+        res.status(400).json(error)
+    }
+})
+
+
+
 // ============================================================================
 // MCP CLIENT - CORE ENDPOINTS
 // ============================================================================
@@ -1323,23 +1532,23 @@ mainRouter.get('/api/mostActive/:indexSymbol', async (req, res) => {
  */
 mainRouter.post('/api/mcp/query', async (req, res) => {
     try {
-        const { 
-            query, 
-            sessionId: providedSessionId, 
-            userId, 
-            model, 
-            temperature, 
-            max_tokens, 
-            includeContext, 
-            updatePreferences, 
+        const {
+            query,
+            sessionId: providedSessionId,
+            userId,
+            model,
+            temperature,
+            max_tokens,
+            includeContext,
+            updatePreferences,
             useMemory,
             maxIterations,
             enableDebugLogging
         } = req.body as MCPClientRequest
 
         if (!query || typeof query !== 'string') {
-            return res.status(400).json({ 
-                error: 'Query is required and must be a string' 
+            return res.status(400).json({
+                error: 'Query is required and must be a string'
             })
         }
 
@@ -1347,17 +1556,17 @@ mainRouter.post('/api/mcp/query', async (req, res) => {
         const sessionId = providedSessionId || `auto_session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
 
         if (!process.env.OPENAI_API_KEY) {
-            return res.status(500).json({ 
-                error: 'OpenAI API key not configured. Please set OPENAI_API_KEY environment variable.' 
+            return res.status(500).json({
+                error: 'OpenAI API key not configured. Please set OPENAI_API_KEY environment variable.'
             })
         }
 
         // Enable debug logging if requested, or check environment variable
         const shouldEnableDebug = enableDebugLogging || process.env.MCP_DEBUG_LOGGING === 'true'
-        
+
         // Store original debug state to restore later
         const originalDebugState = mcpClient.isDebugLoggingEnabled()
-        
+
         // Temporarily enable debug logging if requested
         if (shouldEnableDebug) {
             mcpClient.setDebugLogging(true)
@@ -1384,8 +1593,8 @@ mainRouter.post('/api/mcp/query', async (req, res) => {
         }
     } catch (error) {
         console.error('MCP Query Error:', error)
-        res.status(500).json({ 
-            error: error instanceof Error ? error.message : 'Internal server error' 
+        res.status(500).json({
+            error: error instanceof Error ? error.message : 'Internal server error'
         })
     }
 })
@@ -1428,8 +1637,8 @@ mainRouter.get('/api/mcp/tools', async (_req, res) => {
         res.json({ tools })
     } catch (error) {
         console.error('MCP Tools Error:', error)
-        res.status(500).json({ 
-            error: error instanceof Error ? error.message : 'Internal server error' 
+        res.status(500).json({
+            error: error instanceof Error ? error.message : 'Internal server error'
         })
     }
 })
@@ -1465,7 +1674,7 @@ mainRouter.get('/api/mcp/tools', async (_req, res) => {
 mainRouter.get('/api/mcp/test', async (_req, res) => {
     try {
         if (!process.env.OPENAI_API_KEY) {
-            return res.status(500).json({ 
+            return res.status(500).json({
                 status: 'error',
                 message: 'OpenAI API key not configured',
                 timestamp: new Date().toISOString()
@@ -1473,7 +1682,7 @@ mainRouter.get('/api/mcp/test', async (_req, res) => {
         }
 
         const isConnected = await mcpClient.testConnection()
-        
+
         if (isConnected) {
             res.json({
                 status: 'success',
@@ -1489,7 +1698,7 @@ mainRouter.get('/api/mcp/test', async (_req, res) => {
         }
     } catch (error) {
         console.error('MCP Test Error:', error)
-        res.status(500).json({ 
+        res.status(500).json({
             status: 'error',
             message: error instanceof Error ? error.message : 'Test failed',
             timestamp: new Date().toISOString()
@@ -1539,8 +1748,8 @@ mainRouter.get('/api/mcp/functions', async (_req, res) => {
         res.json({ functions })
     } catch (error) {
         console.error('MCP Functions Error:', error)
-        res.status(500).json({ 
-            error: error instanceof Error ? error.message : 'Internal server error' 
+        res.status(500).json({
+            error: error instanceof Error ? error.message : 'Internal server error'
         })
     }
 })
@@ -1596,18 +1805,18 @@ mainRouter.get('/api/mcp/session/:sessionId', async (req, res) => {
     try {
         const { sessionId } = req.params
         const sessionInfo = mcpClient.getSessionInfo(sessionId)
-        
+
         if (!sessionInfo) {
-            return res.status(404).json({ 
-                error: 'Session not found' 
+            return res.status(404).json({
+                error: 'Session not found'
             })
         }
 
         res.json(sessionInfo)
     } catch (error) {
         console.error('Get Session Info Error:', error)
-        res.status(500).json({ 
-            error: error instanceof Error ? error.message : 'Internal server error' 
+        res.status(500).json({
+            error: error instanceof Error ? error.message : 'Internal server error'
         })
     }
 })
@@ -1667,23 +1876,23 @@ mainRouter.get('/api/mcp/session/:sessionId/history', async (req, res) => {
     try {
         const { sessionId } = req.params
         const { maxMessages } = req.query
-        
+
         const history = mcpClient.getConversationHistory(
-            sessionId, 
+            sessionId,
             maxMessages ? parseInt(maxMessages as string) : undefined
         )
-        
+
         if (history.length === 0) {
-            return res.status(404).json({ 
-                error: 'Session not found or no history available' 
+            return res.status(404).json({
+                error: 'Session not found or no history available'
             })
         }
 
         res.json({ messages: history })
     } catch (error) {
         console.error('Get Conversation History Error:', error)
-        res.status(500).json({ 
-            error: error instanceof Error ? error.message : 'Internal server error' 
+        res.status(500).json({
+            error: error instanceof Error ? error.message : 'Internal server error'
         })
     }
 })
@@ -1750,15 +1959,15 @@ mainRouter.put('/api/mcp/session/:sessionId/preferences', async (req, res) => {
         const preferences = req.body
 
         mcpClient.updateUserPreferences(sessionId, preferences)
-        
-        res.json({ 
+
+        res.json({
             message: 'Preferences updated successfully',
-            sessionId 
+            sessionId
         })
     } catch (error) {
         console.error('Update Preferences Error:', error)
-        res.status(500).json({ 
-            error: error instanceof Error ? error.message : 'Internal server error' 
+        res.status(500).json({
+            error: error instanceof Error ? error.message : 'Internal server error'
         })
     }
 })
@@ -1786,17 +1995,17 @@ mainRouter.put('/api/mcp/session/:sessionId/preferences', async (req, res) => {
 mainRouter.delete('/api/mcp/session/:sessionId/clear', async (req, res) => {
     try {
         const { sessionId } = req.params
-        
+
         mcpClient.clearSession(sessionId)
-        
-        res.json({ 
+
+        res.json({
             message: 'Session cleared successfully',
-            sessionId 
+            sessionId
         })
     } catch (error) {
         console.error('Clear Session Error:', error)
-        res.status(500).json({ 
-            error: error instanceof Error ? error.message : 'Internal server error' 
+        res.status(500).json({
+            error: error instanceof Error ? error.message : 'Internal server error'
         })
     }
 })
@@ -1825,18 +2034,18 @@ mainRouter.get('/api/mcp/session/:sessionId/export', async (req, res) => {
     try {
         const { sessionId } = req.params
         const sessionData = mcpClient.exportSessionData(sessionId)
-        
+
         if (!sessionData) {
-            return res.status(404).json({ 
-                error: 'Session not found' 
+            return res.status(404).json({
+                error: 'Session not found'
             })
         }
 
         res.json(sessionData)
     } catch (error) {
         console.error('Export Session Data Error:', error)
-        res.status(500).json({ 
-            error: error instanceof Error ? error.message : 'Internal server error' 
+        res.status(500).json({
+            error: error instanceof Error ? error.message : 'Internal server error'
         })
     }
 })
@@ -1855,15 +2064,15 @@ mainRouter.get('/api/mcp/session/:sessionId/export', async (req, res) => {
 mainRouter.post('/api/mcp/cleanup', async (_req, res) => {
     try {
         mcpClient.cleanupExpiredSessions()
-        
-        res.json({ 
+
+        res.json({
             message: 'Cleanup completed successfully',
             timestamp: new Date().toISOString()
         })
     } catch (error) {
         console.error('Cleanup Error:', error)
-        res.status(500).json({ 
-            error: error instanceof Error ? error.message : 'Internal server error' 
+        res.status(500).json({
+            error: error instanceof Error ? error.message : 'Internal server error'
         })
     }
 })
@@ -1913,12 +2122,12 @@ mainRouter.get('/api/mcp/session/:sessionId/context-stats', async (req, res) => 
     try {
         const { sessionId } = req.params
         const stats = await mcpClient.getContextStats(sessionId)
-        
+
         res.json(stats)
     } catch (error) {
         console.error('Get Context Stats Error:', error)
-        res.status(500).json({ 
-            error: error instanceof Error ? error.message : 'Internal server error' 
+        res.status(500).json({
+            error: error instanceof Error ? error.message : 'Internal server error'
         })
     }
 })
@@ -1958,21 +2167,21 @@ mainRouter.post('/api/mcp/session/:sessionId/summarize', async (req, res) => {
     try {
         const { sessionId } = req.params
         const summary = await mcpClient.forceContextSummarization(sessionId)
-        
+
         if (!summary) {
-            return res.status(404).json({ 
-                error: 'Session not found' 
+            return res.status(404).json({
+                error: 'Session not found'
             })
         }
 
-        res.json({ 
+        res.json({
             summary,
             message: 'Context summarization completed successfully'
         })
     } catch (error) {
         console.error('Context Summarization Error:', error)
-        res.status(500).json({ 
-            error: error instanceof Error ? error.message : 'Internal server error' 
+        res.status(500).json({
+            error: error instanceof Error ? error.message : 'Internal server error'
         })
     }
 })
@@ -2001,8 +2210,8 @@ mainRouter.get('/api/mcp/session/:sessionId/context-window', async (req, res) =>
         res.json(config)
     } catch (error) {
         console.error('Get Context Window Config Error:', error)
-        res.status(500).json({ 
-            error: error instanceof Error ? error.message : 'Internal server error' 
+        res.status(500).json({
+            error: error instanceof Error ? error.message : 'Internal server error'
         })
     }
 })
@@ -2051,15 +2260,15 @@ mainRouter.put('/api/mcp/session/:sessionId/context-window', async (req, res) =>
     try {
         const config = req.body
         mcpClient.updateContextWindowConfig(config)
-        
-        res.json({ 
+
+        res.json({
             message: 'Context window configuration updated successfully',
             config: mcpClient.getContextWindowConfig()
         })
     } catch (error) {
         console.error('Update Context Window Config Error:', error)
-        res.status(500).json({ 
-            error: error instanceof Error ? error.message : 'Internal server error' 
+        res.status(500).json({
+            error: error instanceof Error ? error.message : 'Internal server error'
         })
     }
 })
@@ -2091,24 +2300,24 @@ mainRouter.put('/api/mcp/session/:sessionId/context-window', async (req, res) =>
 mainRouter.get('/api/mcp/session/:sessionId/summarization/last', async (req, res) => {
     try {
         const { sessionId } = req.params
-        
+
         if (!mcpClient.isMemoryEnabled()) {
             return res.status(500).json({ error: 'Memory manager not enabled' })
         }
 
         const lastSummarization = mcpClient.getLastSummarization(sessionId)
-        
+
         if (!lastSummarization) {
-            return res.status(404).json({ 
-                message: 'No summarization found for this session' 
+            return res.status(404).json({
+                message: 'No summarization found for this session'
             })
         }
 
         res.json(lastSummarization)
     } catch (error) {
         console.error('Get Last Summarization Error:', error)
-        res.status(500).json({ 
-            error: error instanceof Error ? error.message : 'Internal server error' 
+        res.status(500).json({
+            error: error instanceof Error ? error.message : 'Internal server error'
         })
     }
 })
@@ -2140,13 +2349,13 @@ mainRouter.get('/api/mcp/session/:sessionId/summarization/history', async (req, 
     try {
         const { sessionId } = req.params
         const limit = req.query.limit ? parseInt(req.query.limit as string) : undefined
-        
+
         if (!mcpClient.isMemoryEnabled()) {
             return res.status(500).json({ error: 'Memory manager not enabled' })
         }
 
         const history = mcpClient.getSummarizationHistory(sessionId, limit)
-        
+
         res.json({
             sessionId,
             count: history.length,
@@ -2154,8 +2363,8 @@ mainRouter.get('/api/mcp/session/:sessionId/summarization/history', async (req, 
         })
     } catch (error) {
         console.error('Get Summarization History Error:', error)
-        res.status(500).json({ 
-            error: error instanceof Error ? error.message : 'Internal server error' 
+        res.status(500).json({
+            error: error instanceof Error ? error.message : 'Internal server error'
         })
     }
 })
@@ -2181,24 +2390,24 @@ mainRouter.get('/api/mcp/session/:sessionId/summarization/history', async (req, 
 mainRouter.get('/api/mcp/session/:sessionId/summarization/summary', async (req, res) => {
     try {
         const { sessionId } = req.params
-        
+
         if (!mcpClient.isMemoryEnabled()) {
             return res.status(500).json({ error: 'Memory manager not enabled' })
         }
 
         const summary = mcpClient.getSummarizationSummary(sessionId)
-        
+
         if (!summary) {
-            return res.status(404).json({ 
-                message: 'Session not found' 
+            return res.status(404).json({
+                message: 'Session not found'
             })
         }
 
         res.json(summary)
     } catch (error) {
         console.error('Get Summarization Summary Error:', error)
-        res.status(500).json({ 
-            error: error instanceof Error ? error.message : 'Internal server error' 
+        res.status(500).json({
+            error: error instanceof Error ? error.message : 'Internal server error'
         })
     }
 })
@@ -2224,19 +2433,19 @@ mainRouter.get('/api/mcp/session/:sessionId/summarization/summary', async (req, 
 mainRouter.get('/api/mcp/session/:sessionId/openai-messages', async (req, res) => {
     try {
         const { sessionId } = req.params
-        
+
         if (!mcpClient.isMemoryEnabled()) {
             return res.status(500).json({ error: 'Memory manager not enabled' })
         }
 
         const data = mcpClient.getOpenAIMessages(sessionId)
-        
+
         if (!data) {
             return res.status(404).json({ error: 'Session not found' })
         }
-        
+
         // Format messages as they would be sent to OpenAI
-            const openaiMessages = [
+        const openaiMessages = [
             {
                 role: 'system',
                 content: data.systemPrompt,
@@ -2259,7 +2468,7 @@ mainRouter.get('/api/mcp/session/:sessionId/openai-messages', async (req, res) =
 
         // Calculate statistics
         const summaryMessages = openaiMessages.filter(
-          m => m.metadata && 'is_summary' in m.metadata && m.metadata.is_summary
+            m => m.metadata && 'is_summary' in m.metadata && m.metadata.is_summary
         )
         const stats = {
             total_messages: openaiMessages.length,
@@ -2277,8 +2486,8 @@ mainRouter.get('/api/mcp/session/:sessionId/openai-messages', async (req, res) =
         })
     } catch (error) {
         console.error('Get OpenAI Messages Error:', error)
-        res.status(500).json({ 
-            error: error instanceof Error ? error.message : 'Internal server error' 
+        res.status(500).json({
+            error: error instanceof Error ? error.message : 'Internal server error'
         })
     }
 })


### PR DESCRIPTION
# Add OHLC Chart Data & Symbol Scripcode Lookup for NSE Charting API

## Summary

This PR introduces two new features built on top of `charting.nseindia.com`:

1. **OHLC Historical Chart Data** — fetch intraday and daily OHLC candle data for any equity symbol (distinct from the existing EOD historical data)
2. **Symbol Script Code Lookup** — resolve any equity symbol to its NSE `scripCode`, which is the internal identifier required by the charting API (referred to as `token` in API parameters)

> **Note on naming:** NSE already has an EOD historical data API (`getEquityHistoricalData`). This PR adds a separate charting-domain API that returns **OHLC candle data** at configurable time intervals (1m, 5m, 15m, 30m, 60m, daily). The word "OHLC" is used throughout to keep these two distinct.

The charting domain uses a different authentication flow. This PR also introduces a dedicated cookie handler for `charting.nseindia.com` with the same caching strategy as the primary NSE domain — with NSE cookies tried first as a performance optimisation.

## Changes

### Core Library (`src/index.ts`, `src/interface.ts`)

- **New `getEquitySymbolInfo(symbol, segment?)`** — queries `charting.nseindia.com/v1/exchanges/symbolsDynamic` to resolve a symbol (e.g. `ONGC-EQ`) into its `scripCode` and other metadata.
- **New `ChartingSymbolInfo` interface** — typed response from the symbol lookup API.
- **New `ChartingOHLCItem` & `ChartingOHLCResponse` interfaces** — full type safety for the OHLC candle data (includes `open`, `high`, `low`, `close`, `volume`, `time`).
- **New `getEquityChartHistoricalData()`** — fetches OHLC candle data from the charting domain. The `token` (`scripCode`) parameter is optional; when omitted, it is auto-resolved via `getEquitySymbolInfo`. Returns a typed `Promise<ChartingOHLCResponse>`.
- **New `getChartingCookies()`** (private) — cookie handler for the charting domain with 60-sec TTL and refresh after 10 requests.
- **Updated `getData()`** — supports a `domain` parameter (`'nse' | 'charting'`) to route requests to the correct domain with the right authentication headers.

### REST API (`src/routes.ts`)

| Method | Endpoint | Description |
|--------|----------|-------------|
| `GET` | `/api/v1/charts/symbol-info` | **New** — resolve a symbol to its `scripCode` (token) |
| `GET` | `/api/v1/charts/equity-historical-data` | **New** — fetch OHLC candle data; `token` is optional |

Both endpoints have full Swagger/OpenAPI documentation with examples.

### MCP Tools (`src/mcp/mcp-tools.ts`)

- **New tool `get_equity_chart_symbol_info`** — AI agents can use this to look up a `scripCode` before fetching OHLC data.
- **New tool `get_equity_chart_historical_data`** — fetches OHLC candle data; `token` is not required (auto-fetched if missing).

### Tests (`src/index.spec.ts`)

- `getEquitySymbolInfo` — verifies `scripCode` is returned and non-empty for a real symbol.
- `getEquityChartHistoricalData` — verifies OHLC response structure with an explicit token.
- `getEquityChartHistoricalData without token` — verifies the auto-lookup path works end-to-end.

## Cookie Strategy

| Step | Domain Tried | When |
|------|-------------|------|
| Primary | NSE cookies | Always first (fastest, no extra request) |
| Fallback | Charting cookies | Only if NSE cookies are rejected by the charting API |

## Usage

```bash
# Look up the scripCode for a symbol
GET /api/v1/charts/symbol-info?symbol=ONGC-EQ
# → { "scripCode": "2475", "symbol": "ONGC-EQ", "companyName": "...", ... }

# Fetch OHLC data — with explicit token
GET /api/v1/charts/equity-historical-data?symbol=ONGC-EQ&fromDate=1775834999&toDate=1775999513&token=2475

# Fetch OHLC data — token auto-resolved internally
GET /api/v1/charts/equity-historical-data?symbol=ONGC-EQ&fromDate=1775834999&toDate=1775999513
```

```typescript
// Look up scripCode
const { scripCode } = await nseIndia.getEquitySymbolInfo('ONGC-EQ')

// Fetch OHLC candles — explicit token
const chartData = await nseIndia.getEquityChartHistoricalData('ONGC-EQ', '1775834999', '1775999513', scripCode)

// Fetch OHLC candles — token auto-fetched
const chartData = await nseIndia.getEquityChartHistoricalData('ONGC-EQ', '1775834999', '1775999513')
```

## Checklist
- [x] TypeScript compilation passes (`npm run build`)
- [x] Unit tests pass — symbol lookup, OHLC with token, OHLC without token
- [x] Swagger docs updated for both new endpoints
- [x] MCP tool schemas defined for both new tools
- [x] Cookie fallback strategy implemented and tested
