### PR TITLE
Refine charting APIs with flexible date range and token auto-resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,9 +336,9 @@ console.log(symbolInfo.scripcode);
 
 - **`GET /api/charts/equity-historical-data`**
   - Required: `symbol`
-  - Optional: `fromDate`, `toDate` (format: `YYYY-MM-DD`), `token`, `symbolType`, `chartType`, `timeInterval`
+  - Optional: `start`, `end` (`YYYY-MM-DD`, `YYYY-MM-DD HH:MM:SS`, or unix timestamp), `token`, `symbolType`, `chartType`, `timeInterval`
   - If `token` is omitted, the API auto-fetches it.
-  - If both `fromDate` and `toDate` are omitted, default range is used.
+  - If both `start` and `end` are omitted, default range is used.
   - If only one date is provided, the other date is auto-derived.
 
 - **`GET /api/charts/symbol-info`**

--- a/README.md
+++ b/README.md
@@ -295,6 +295,8 @@ Comprehensive REST endpoints with automatic Swagger documentation:
 - `GET /api/equity/:symbol` - Equity details
 - `GET /api/equity/:symbol/historical` - Historical data
 - `GET /api/indices` - Market indices
+- `GET /api/charts/equity-historical-data` - Charting OHLC historical data
+- `GET /api/charts/symbol-info` - Charting symbol/token lookup
 - `GET /api-docs` - Interactive API documentation
 
 ### MCP Client Endpoints
@@ -305,6 +307,44 @@ Comprehensive REST endpoints with automatic Swagger documentation:
 ### API Documentation
 
 Visit `http://localhost:3000/api-docs` for complete interactive API documentation powered by Swagger UI.
+
+### Charting APIs
+
+#### NPM Package Methods
+
+```javascript
+import { NseIndia } from "stock-nse-india";
+
+const nseIndia = new NseIndia();
+
+// Optional date range and optional token.
+// If token is omitted, it is auto-fetched internally using getEquitySymbolInfo().
+const chartData = await nseIndia.getEquityChartHistoricalData(
+  "ONGC",
+  {
+    start: new Date("2026-04-10"),
+    end: new Date("2026-04-12")
+  }
+);
+
+// You can also fetch symbol info/token explicitly.
+const symbolInfo = await nseIndia.getEquitySymbolInfo("ONGC");
+console.log(symbolInfo.scripcode);
+```
+
+#### REST Endpoints
+
+- **`GET /api/charts/equity-historical-data`**
+  - Required: `symbol`
+  - Optional: `fromDate`, `toDate` (format: `YYYY-MM-DD`), `token`, `symbolType`, `chartType`, `timeInterval`
+  - If `token` is omitted, the API auto-fetches it.
+  - If both `fromDate` and `toDate` are omitted, default range is used.
+  - If only one date is provided, the other date is auto-derived.
+
+- **`GET /api/charts/symbol-info`**
+  - Required: `symbol`
+  - Optional: `segment`
+  - Returns charting symbol details including `scripcode` (token).
 
 ## 💻 CLI Usage
 
@@ -401,6 +441,11 @@ CORS_CREDENTIALS=true
 - **`getEquityOptionChain(symbol)`** - Options chain data
 - **`getEquityCorporateInfo(symbol)`** - Corporate information
 - **`getEquityTradeInfo(symbol)`** - Trading statistics
+
+### Charting Methods
+
+- **`getEquityChartHistoricalData(symbol, range?, token?, symbolType?, chartType?, timeInterval?)`** - Get charting OHLC historical data
+- **`getEquitySymbolInfo(symbol, segment?)`** - Resolve charting symbol/token (`scripcode`)
 
 ### Index Methods
 

--- a/src/index.charting.spec.ts
+++ b/src/index.charting.spec.ts
@@ -1,0 +1,87 @@
+import axios from 'axios'
+import { NseIndia } from './index'
+
+jest.mock('axios')
+
+describe('NseIndia charting API tests', () => {
+    const mockedAxios = axios as jest.Mocked<typeof axios>
+
+    beforeEach(() => {
+        mockedAxios.get.mockReset()
+    })
+
+    test('getChartingCookies refreshes and then reuses cached cookies', async () => {
+        const nseIndia = new NseIndia() as any
+
+        mockedAxios.get.mockResolvedValueOnce({
+            headers: {
+                'set-cookie': ['nsit=abc; Path=/', 'ak_bmsc=xyz; Path=/']
+            }
+        } as any)
+
+        const first = await nseIndia.getChartingCookies()
+        expect(first).toBe('nsit=abc; ak_bmsc=xyz')
+        expect(mockedAxios.get).toHaveBeenCalledTimes(1)
+
+        const second = await nseIndia.getChartingCookies()
+        expect(second).toBe('nsit=abc; ak_bmsc=xyz')
+        expect(mockedAxios.get).toHaveBeenCalledTimes(1)
+    })
+
+    test('getData falls back to charting cookies when NSE cookies fail', async () => {
+        const nseIndia = new NseIndia() as any
+        jest.spyOn(nseIndia, 'getNseCookies').mockResolvedValue('nse_cookie=primary')
+        jest.spyOn(nseIndia, 'getChartingCookies').mockResolvedValue('chart_cookie=fallback')
+
+        mockedAxios.get
+            .mockRejectedValueOnce(new Error('primary cookie failed'))
+            .mockResolvedValueOnce({ data: { status: true, data: [] } } as any)
+
+        const result = await nseIndia.getData('https://charting.nseindia.com/v1/test', 'charting')
+
+        expect(result).toEqual({ status: true, data: [] })
+        expect(mockedAxios.get).toHaveBeenCalledTimes(2)
+        expect(mockedAxios.get.mock.calls[1][1]?.headers?.Cookie).toBe('chart_cookie=fallback')
+    })
+
+    test('getEquitySymbolInfo throws when charting API returns empty list', async () => {
+        const nseIndia = new NseIndia() as any
+        jest.spyOn(nseIndia, 'getData').mockResolvedValue([])
+
+        await expect(nseIndia.getEquitySymbolInfo('ONGC')).rejects.toThrow(
+            'No symbol info found for: ONGC'
+        )
+    })
+
+    test('getEquityChartHistoricalData uses default date range when range is omitted', async () => {
+        const nseIndia = new NseIndia() as any
+        jest.spyOn(nseIndia, 'getData').mockResolvedValue({ status: true, data: [] })
+
+        const response = await nseIndia.getEquityChartHistoricalData('ONGC', undefined, '2475')
+
+        expect(response).toEqual({ status: true, data: [] })
+        expect(nseIndia.getData).toHaveBeenCalledWith(
+            expect.stringContaining('symbolHistoricalData?fromDate='),
+            'charting'
+        )
+    })
+
+    test('getEquitySymbolInfo falls back to first item when exact symbol is missing', async () => {
+        const nseIndia = new NseIndia() as any
+        jest.spyOn(nseIndia, 'getData').mockResolvedValue([
+            {
+                symbol: 'ONGC',
+                scripcode: '2475',
+                companyName: 'Oil & Natural Gas Corporation',
+                isin: 'INE213A01029',
+                segment: 'CM',
+                series: 'EQ'
+            }
+        ])
+
+        const info = await nseIndia.getEquitySymbolInfo('UNKNOWN')
+
+        expect(info.symbol).toBe('ONGC')
+        expect(info.scripcode).toBe('2475')
+    })
+})

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -304,7 +304,7 @@ describe('Class: NseIndia', () => {
     test('getEquityChartHistoricalData', async () => {
         // Test charting API with real parameters
         const chartData = await nseIndia.getEquityChartHistoricalData(
-            'ONGC-EQ',
+            'ONGC',
             {
                 start: new Date(1775834999 * 1000),
                 end: new Date(1775999513 * 1000)
@@ -327,7 +327,7 @@ describe('Class: NseIndia', () => {
     })
 
     test('getEquitySymbolInfo', async () => {
-        const info = await nseIndia.getEquitySymbolInfo('ONGC-EQ')
+        const info = await nseIndia.getEquitySymbolInfo('ONGC')
         expect(info).toBeDefined()
         expect(info).toHaveProperty('symbol')
         expect(info).toHaveProperty('scripcode')
@@ -339,7 +339,7 @@ describe('Class: NseIndia', () => {
     test('getEquityChartHistoricalData without token (auto-lookup)', async () => {
         // Token omitted — the method should call getEquitySymbolInfo internally
         const chartData = await nseIndia.getEquityChartHistoricalData(
-            'ONGC-EQ',
+            'ONGC',
             {
                 start: new Date(1775834999 * 1000),
                 end: new Date(1775999513 * 1000)

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -305,8 +305,10 @@ describe('Class: NseIndia', () => {
         // Test charting API with real parameters
         const chartData = await nseIndia.getEquityChartHistoricalData(
             'ONGC-EQ',
-            '1775834999',
-            '1775999513',
+            {
+                start: new Date(1775834999 * 1000),
+                end: new Date(1775999513 * 1000)
+            },
             '2475',
             'Equity',
             'I',
@@ -328,18 +330,20 @@ describe('Class: NseIndia', () => {
         const info = await nseIndia.getEquitySymbolInfo('ONGC-EQ')
         expect(info).toBeDefined()
         expect(info).toHaveProperty('symbol')
-        expect(info).toHaveProperty('scripCode')
-        // scripCode is the token required by the chart API — must be a non-empty string
-        expect(typeof info.scripCode).toBe('string')
-        expect(info.scripCode.length).toBeGreaterThan(0)
+        expect(info).toHaveProperty('scripcode')
+        // scripcode is the token required by the chart API — must be a non-empty string
+        expect(typeof info.scripcode).toBe('string')
+        expect(info.scripcode.length).toBeGreaterThan(0)
     })
 
     test('getEquityChartHistoricalData without token (auto-lookup)', async () => {
         // Token omitted — the method should call getEquitySymbolInfo internally
         const chartData = await nseIndia.getEquityChartHistoricalData(
             'ONGC-EQ',
-            '1775834999',
-            '1775999513'
+            {
+                start: new Date(1775834999 * 1000),
+                end: new Date(1775999513 * 1000)
+            }
             // no token — should auto-fetch via symbolsDynamic
         )
         expect(chartData).toBeDefined()

--- a/src/index.ts
+++ b/src/index.ts
@@ -244,8 +244,7 @@ export class NseIndia {
     /**
      * Get historical chart data from charting.nseindia.com
      * @param symbol Equity symbol with series (e.g., 'ONGC-EQ')
-     * @param fromDate Unix timestamp for start date
-     * @param toDate Unix timestamp for end date
+     * @param range Optional date range for chart data query
      * @param token NSE script code (token) for the symbol. If not provided, it is
      *              automatically fetched via {@link getEquitySymbolInfo}.
      * @param symbolType Type of symbol (e.g., 'Equity', 'Index')
@@ -255,18 +254,22 @@ export class NseIndia {
      */
     async getEquityChartHistoricalData(
         symbol: string,
-        fromDate: string | number,
-        toDate: string | number,
+        range?: DateRange,
         token?: string | number,
         symbolType = 'Equity',
         chartType = 'I',
         timeInterval: string | number = '5'
     ): Promise<ChartingOHLCResponse> {
+        const endDate = range?.end ?? new Date()
+        const startDate = range?.start ?? new Date(endDate.getTime() - 24 * 60 * 60 * 1000)
+        const fromDate = Math.floor(startDate.getTime() / 1000)
+        const toDate = Math.floor(endDate.getTime() / 1000)
+
         // Auto-fetch token (scripCode) when not supplied by the caller
         let resolvedToken = token
         if (!resolvedToken) {
             const symbolInfo = await this.getEquitySymbolInfo(symbol)
-            resolvedToken = symbolInfo.scripCode
+            resolvedToken = symbolInfo.scripcode
         }
 
         const url = `${this.chartingBaseUrl}/v1/charts/symbolHistoricalData?` +

--- a/src/index.ts
+++ b/src/index.ts
@@ -243,7 +243,7 @@ export class NseIndia {
 
     /**
      * Get historical chart data from charting.nseindia.com
-     * @param symbol Equity symbol with series (e.g., 'ONGC-EQ')
+     * @param symbol Equity symbol with series (e.g., 'ONGC')
      * @param range Optional date range for chart data query
      * @param token NSE script code (token) for the symbol. If not provided, it is
      *              automatically fetched via {@link getEquitySymbolInfo}.
@@ -288,7 +288,7 @@ export class NseIndia {
      * Look up the NSE script code (token) for an equity symbol using the charting domain.
      * The `scripCode` in the returned object is the value that must be passed as `token`
      * to {@link getEquityChartHistoricalData}.
-     * @param symbol Equity symbol with series code (e.g., 'ONGC-EQ') OR plain symbol (e.g., 'ONGC')
+     * @param symbol Equity symbol with series code (e.g., 'ONGC') OR plain symbol (e.g., 'ONGC')
      * @param segment Optional market segment filter (default: empty string, returns all segments)
      * @returns Symbol information including scripCode / token
      */

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -14,7 +14,7 @@ export interface IntradayData {
  */
 export interface ChartingSymbolInfo {
     symbol: string
-    scripCode: string   // This is the "token" required by the historical chart API
+    scripcode: string   // This is the "token" required by the historical chart API
     companyName: string
     isin: string
     segment: string

--- a/src/mcp/mcp-tools.ts
+++ b/src/mcp/mcp-tools.ts
@@ -394,7 +394,7 @@ export const mcpTools = [
       properties: {
         symbol: {
           type: 'string',
-          description: 'Equity symbol with series code (e.g., ONGC-EQ, TCS-EQ)',
+          description: 'Equity symbol with series code (e.g., ONGC, TCS)',
         },
         from_date: {
           type: 'string',
@@ -435,7 +435,7 @@ export const mcpTools = [
       properties: {
         symbol: {
           type: 'string',
-          description: 'Equity symbol with or without series code (e.g., ONGC-EQ or ONGC)',
+          description: 'Equity symbol with or without series code (e.g., ONGC or ONGC)',
         },
         segment: {
           type: 'string',

--- a/src/mcp/mcp-tools.ts
+++ b/src/mcp/mcp-tools.ts
@@ -396,13 +396,13 @@ export const mcpTools = [
           type: 'string',
           description: 'Equity symbol with series code (e.g., ONGC, TCS)',
         },
-        from_date: {
+        start: {
           type: 'string',
-          description: 'Unix timestamp for start date (e.g., 1775834999)',
+          description: 'Optional unix timestamp for start date (e.g., 1775834999)',
         },
-        to_date: {
+        end: {
           type: 'string',
-          description: 'Unix timestamp for end date (e.g., 1775999513)',
+          description: 'Optional unix timestamp for end date (e.g., 1775999513)',
         },
         token: {
           type: 'string',
@@ -422,7 +422,7 @@ export const mcpTools = [
           description: 'Time interval in minutes - 1, 5, 15, 30, 60. (default: 5)',
         },
       },
-      required: ['symbol', 'from_date', 'to_date'],
+      required: ['symbol'],
     },
   },
   {
@@ -876,11 +876,16 @@ export async function handleMCPToolCall(
       if (!args?.symbol || typeof args.symbol !== 'string') {
         throw new Error('Symbol parameter is required and must be a string')
       }
-      if (!args?.from_date || typeof args.from_date !== 'string') {
-        throw new Error('from_date parameter is required and must be a string (unix timestamp)')
+      const startInput = args?.start ?? args?.from_date
+      const endInput = args?.end ?? args?.to_date
+      const hasStartDate = startInput !== undefined && startInput !== null
+      const hasEndDate = endInput !== undefined && endInput !== null
+
+      if (hasStartDate && typeof startInput !== 'string') {
+        throw new Error('start parameter must be a string (unix timestamp)')
       }
-      if (!args?.to_date || typeof args.to_date !== 'string') {
-        throw new Error('to_date parameter is required and must be a string (unix timestamp)')
+      if (hasEndDate && typeof endInput !== 'string') {
+        throw new Error('end parameter must be a string (unix timestamp)')
       }
 
       // token is now optional — the core method auto-fetches it via getEquitySymbolInfo
@@ -896,9 +901,18 @@ export async function handleMCPToolCall(
         ? args.time_interval
         : '5'
 
-      const range = {
-        start: new Date(Number(args.from_date) * 1000),
-        end: new Date(Number(args.to_date) * 1000)
+      let range
+      if (hasStartDate || hasEndDate) {
+        const end = hasEndDate
+          ? new Date(Number(endInput) * 1000)
+          : new Date()
+        const start = hasStartDate
+          ? new Date(Number(startInput) * 1000)
+          : new Date(end.getTime() - 24 * 60 * 60 * 1000)
+        if (!(start.getTime() > 0 && end.getTime() > 0)) {
+          throw new Error('Invalid date format. start/end must be unix timestamps')
+        }
+        range = { start, end }
       }
 
       result = await nseClient.getEquityChartHistoricalData(

--- a/src/mcp/mcp-tools.ts
+++ b/src/mcp/mcp-tools.ts
@@ -896,10 +896,14 @@ export async function handleMCPToolCall(
         ? args.time_interval
         : '5'
 
+      const range = {
+        start: new Date(Number(args.from_date) * 1000),
+        end: new Date(Number(args.to_date) * 1000)
+      }
+
       result = await nseClient.getEquityChartHistoricalData(
         args.symbol,
-        args.from_date,
-        args.to_date,
+        range,
         token,
         symbolType,
         chartType,

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1196,22 +1196,24 @@ mainRouter.get('/api/mostActive/:indexSymbol', async (req, res) => {
  *         schema:
  *           type: string
  *           example: ONGC
- *       - name: fromDate
+ *       - name: start
  *         in: query
- *         description: "Start date to pull chart data (format: YYYY-MM-DD)"
+ *         description: >
+ *           Start date/time. Supports YYYY-MM-DD, YYYY-MM-DD HH:MM:SS, unix timestamp
+ *           (seconds or milliseconds)
  *         required: false
  *         schema:
  *           type: string
- *           format: date
- *           example: "2026-04-10"
- *       - name: toDate
+ *           example: "2026-04-10 09:15:00"
+ *       - name: end
  *         in: query
- *         description: "End date to pull chart data (format: YYYY-MM-DD)"
+ *         description: >
+ *           End date/time. Supports YYYY-MM-DD, YYYY-MM-DD HH:MM:SS, unix timestamp
+ *           (seconds or milliseconds)
  *         required: false
  *         schema:
  *           type: string
- *           format: date
- *           example: "2026-04-12"
+ *           example: "2026-04-12 15:30:00"
  *       - name: token
  *         in: query
  *         description: Optional token value for charting API (auto-fetched when omitted)
@@ -1287,8 +1289,8 @@ mainRouter.get('/api/charts/equity-historical-data', async (req, res) => {
     try {
         const {
             symbol,
-            fromDate,
-            toDate,
+            start,
+            end,
             token,
             symbolType = 'Equity',
             chartType = 'I',
@@ -1300,18 +1302,31 @@ mainRouter.get('/api/charts/equity-historical-data', async (req, res) => {
             return res.status(400).json({ error: 'Missing required parameter: symbol' })
         }
         // Call the charting method
+        const parseChartDateParam = (value: unknown): Date => {
+            const input = String(value).trim()
+            const numeric = Number(input)
+            // Accept unix timestamp in seconds (10 digits) or milliseconds (13 digits).
+            if (!Number.isNaN(numeric) && input !== '') {
+                const unixMs = input.length <= 10 ? numeric * 1000 : numeric
+                return new Date(unixMs)
+            }
+            return new Date(input)
+        }
+
         let range
-        if (fromDate || toDate) {
-            const end = toDate ? new Date(String(toDate)) : new Date()
-            const start = fromDate
-                ? new Date(String(fromDate))
-                : new Date(end.getTime() - 24 * 60 * 60 * 1000)
-            if (start.getTime() <= 0 || end.getTime() <= 0) {
-                return res.status(400).json({ error: 'Invalid date format. Please use the format (YYYY-MM-DD)' })
+        if (start || end) {
+            const endDate = end ? parseChartDateParam(end) : new Date()
+            const startDate = start
+                ? parseChartDateParam(start)
+                : new Date(endDate.getTime() - 24 * 60 * 60 * 1000)
+            if (!(startDate.getTime() > 0 && endDate.getTime() > 0)) {
+                return res.status(400).json({
+                    error: 'Invalid date format. Use YYYY-MM-DD, YYYY-MM-DD HH:MM:SS, or unix timestamp'
+                })
             }
             range = {
-                start,
-                end
+                start: startDate,
+                end: endDate
             }
         }
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1181,7 +1181,7 @@ mainRouter.get('/api/mostActive/:indexSymbol', async (req, res) => {
 
 /**
  * @openapi
- * /api/v1/charts/equity-historical-data:
+ * /api/charts/equity-historical-data:
  *   get:
  *     description: Get historical chart data from charting.nseindia.com for equity symbols
  *     tags:
@@ -1191,11 +1191,11 @@ mainRouter.get('/api/mostActive/:indexSymbol', async (req, res) => {
  *     parameters:
  *       - name: symbol
  *         in: query
- *         description: Equity symbol with series code (e.g., 'ONGC-EQ')
+ *         description: Equity symbol with series code (e.g., 'ONGC')
  *         required: true
  *         schema:
  *           type: string
- *           example: ONGC-EQ
+ *           example: ONGC
  *       - name: fromDate
  *         in: query
  *         description: "Start date to pull chart data (format: YYYY-MM-DD)"
@@ -1283,7 +1283,7 @@ mainRouter.get('/api/mostActive/:indexSymbol', async (req, res) => {
  *       400:
  *         description: Returns error object if API call fails or parameters are invalid
  */
-mainRouter.get('/api/v1/charts/equity-historical-data', async (req, res) => {
+mainRouter.get('/api/charts/equity-historical-data', async (req, res) => {
     try {
         const {
             symbol,
@@ -1332,12 +1332,12 @@ mainRouter.get('/api/v1/charts/equity-historical-data', async (req, res) => {
 
 /**
  * @openapi
- * /api/v1/charts/symbol-info:
+ * /api/charts/symbol-info:
  *   get:
  *     description: >
  *       Look up NSE charting symbol information (including scripCode / token) for a
  *       given equity symbol. The returned `scripCode` is the value that must be passed
- *       as `token` to the `/api/v1/charts/equity-historical-data` endpoint.
+ *       as `token` to the `/api/charts/equity-historical-data` endpoint.
  *     tags:
  *       - Charting
  *     produces:
@@ -1345,11 +1345,11 @@ mainRouter.get('/api/v1/charts/equity-historical-data', async (req, res) => {
  *     parameters:
  *       - name: symbol
  *         in: query
- *         description: Equity symbol with or without series code (e.g., 'ONGC-EQ' or 'ONGC')
+ *         description: Equity symbol with or without series code (e.g., 'ONGC' or 'ONGC')
  *         required: true
  *         schema:
  *           type: string
- *           example: ONGC-EQ
+ *           example: ONGC
  *       - name: segment
  *         in: query
  *         description: Optional market segment filter (leave empty to search all segments)
@@ -1367,7 +1367,7 @@ mainRouter.get('/api/v1/charts/equity-historical-data', async (req, res) => {
  *               properties:
  *                 symbol:
  *                   type: string
- *                   example: ONGC-EQ
+ *                   example: ONGC
  *                 scripCode:
  *                   type: string
  *                   description: The token value required by the historical chart API
@@ -1385,7 +1385,7 @@ mainRouter.get('/api/v1/charts/equity-historical-data', async (req, res) => {
  *       400:
  *         description: Returns error if symbol is missing or lookup fails
  */
-mainRouter.get('/api/v1/charts/symbol-info', async (req, res) => {
+mainRouter.get('/api/charts/symbol-info', async (req, res) => {
     try {
         const { symbol, segment = '' } = req.query
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1198,22 +1198,24 @@ mainRouter.get('/api/mostActive/:indexSymbol', async (req, res) => {
  *           example: ONGC-EQ
  *       - name: fromDate
  *         in: query
- *         description: Unix timestamp for start date
- *         required: true
+ *         description: "Start date to pull chart data (format: YYYY-MM-DD)"
+ *         required: false
  *         schema:
- *           type: number
- *           example: 1775834999
+ *           type: string
+ *           format: date
+ *           example: "2026-04-10"
  *       - name: toDate
  *         in: query
- *         description: Unix timestamp for end date
- *         required: true
+ *         description: "End date to pull chart data (format: YYYY-MM-DD)"
+ *         required: false
  *         schema:
- *           type: number
- *           example: 1775999513
+ *           type: string
+ *           format: date
+ *           example: "2026-04-12"
  *       - name: token
  *         in: query
- *         description: Token value for charting API
- *         required: true
+ *         description: Optional token value for charting API (auto-fetched when omitted)
+ *         required: false
  *         schema:
  *           type: string
  *           example: "2475"
@@ -1283,28 +1285,40 @@ mainRouter.get('/api/mostActive/:indexSymbol', async (req, res) => {
  */
 mainRouter.get('/api/v1/charts/equity-historical-data', async (req, res) => {
     try {
-        const { symbol, fromDate, toDate, token, symbolType = 'Equity', chartType = 'I', timeInterval = '5' } = req.query
+        const {
+            symbol,
+            fromDate,
+            toDate,
+            token,
+            symbolType = 'Equity',
+            chartType = 'I',
+            timeInterval = '5'
+        } = req.query
 
         // Validate required parameters
         if (!symbol) {
             return res.status(400).json({ error: 'Missing required parameter: symbol' })
         }
-        if (!fromDate) {
-            return res.status(400).json({ error: 'Missing required parameter: fromDate' })
-        }
-        if (!toDate) {
-            return res.status(400).json({ error: 'Missing required parameter: toDate' })
-        }
-        if (!token) {
-            return res.status(400).json({ error: 'Missing required parameter: token' })
+        // Call the charting method
+        let range
+        if (fromDate || toDate) {
+            const end = toDate ? new Date(String(toDate)) : new Date()
+            const start = fromDate
+                ? new Date(String(fromDate))
+                : new Date(end.getTime() - 24 * 60 * 60 * 1000)
+            if (start.getTime() <= 0 || end.getTime() <= 0) {
+                return res.status(400).json({ error: 'Invalid date format. Please use the format (YYYY-MM-DD)' })
+            }
+            range = {
+                start,
+                end
+            }
         }
 
-        // Call the charting method
         const chartData = await nseIndia.getEquityChartHistoricalData(
             String(symbol),
-            String(fromDate),
-            String(toDate),
-            String(token),
+            range,
+            token ? String(token) : undefined,
             String(symbolType),
             String(chartType),
             String(timeInterval)


### PR DESCRIPTION
## Summary

This PR improves the charting API experience across package methods, REST endpoints, and MCP tools by making date inputs optional/flexible and auto-resolving the token when omitted.

## Changes

- Updated `getEquityChartHistoricalData` to accept an optional `range` object (`start`/`end`) instead of required `fromDate`/`toDate` arguments.
- Added default date behavior:
  - no dates provided -> last 24 hours
  - only one date provided -> other date auto-derived
- Made `token` optional; it is auto-fetched internally via `getEquitySymbolInfo` when missing.
- Aligned symbol info field naming with charting responses by using `scripcode`.
- Updated REST chart routes from `/api/v1/charts/*` to `/api/charts/*`.
- Extended REST date parsing to support:
  - `YYYY-MM-DD`
  - `YYYY-MM-DD HH:MM:SS`
  - Unix timestamp (seconds or milliseconds)
- Updated MCP charting tool schema/handler to support optional `start`/`end` while preserving compatibility with legacy `from_date`/`to_date`.
- Added/updated tests for charting cookie fallback, symbol lookup behavior, default ranges, and revised API contracts.
- Expanded `README.md` with charting endpoint/method documentation and examples.

## Why

These changes reduce required inputs for common charting calls, provide sensible defaults, and keep REST/MCP/package contracts aligned with real charting API responses.

## Breaking / Behavior Notes

- REST routes are now:
  - `/api/charts/equity-historical-data`
  - `/api/charts/symbol-info`
- `ChartingSymbolInfo` now uses `scripcode` (lowercase) instead of `scripCode`.
- Chart date parameters now follow `start`/`end` semantics.

## Test Plan

- [x] Run test suite (`npm test`)
- [x] Verify `getEquityChartHistoricalData('ONGC')` works without `token` and without explicit date range
- [x] Verify `GET /api/charts/equity-historical-data?symbol=ONGC` returns data
- [x] Verify date parsing with unix timestamps and `YYYY-MM-DD HH:MM:SS`
- [x] Verify `GET /api/charts/symbol-info?symbol=ONGC` returns `scripcode`
- [x] Verify MCP charting tool with:
  - [x] `symbol` only
  - [x] `start`/`end`